### PR TITLE
Fix the imsize to avoid warnings about inefficient image sizes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+*.ms*
+*.log
+*.last
+*.g
+*.pre
+*.pickle
+*.tt*
+*.alpha*
+*.gridwt
+*.mask
+weblog
+
+.*.swp
+
+applycal_to_orig_MSes.py

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1109,6 +1109,16 @@ def get_spw_chanavg(vis,widtharray,bwarray,chanarray,desiredWidth=15.625e6):
    return avgarray
 
 
+def largest_prime_factor(n):
+    i = 2
+    while i * i <= n:
+        if n % i:
+            i += 1
+        else:
+            n //= i
+    return n
+
+
 def get_image_parameters(vislist,telescope,band,band_properties):
    cells=np.zeros(len(vislist))
    for i in range(len(vislist)):
@@ -1133,6 +1143,10 @@ def get_image_parameters(vislist,telescope,band,band_properties):
    npixels=int(np.ceil(fov/cell / 100.0)) * 100
    if npixels > 16384:
       npixels=16384
+
+   while largest_prime_factor(npixels) >= 7:
+       npixels += 2
+
    return cellsize,npixels,nterms
 
 


### PR DESCRIPTION
It does this by making sure that the largest prime factor of the imsize is < 7.