### PR TITLE
Ensure that the model is applied to all relevant data prior to gaincal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+*.ms*
+*.log
+*.last
+*.g
+*.pre
+*.pickle
+*.tt*
+*.alpha*
+*.gridwt
+*.mask
+weblog
+
+.*.swp
+
+applycal_to_orig_MSes.py

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -502,7 +502,7 @@ for target in all_targets:
          tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration),
                      band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
                      threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_curr'])+'Jy',
-                     savemodel='modelcolumn',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
+                     savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
                      nterms=selfcal_library[target][band]['nterms'],
                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
          print('Pre selfcal assessemnt: '+target)

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -530,6 +530,16 @@ for target in all_targets:
                flagmanager(vis=vis, mode = 'restore', versionname = 'selfcal_starting_flags_'+sani_target, comment = 'Flag states at start of reduction')
             else:
                flagmanager(vis=vis,mode='save',versionname='selfcal_starting_flags_'+sani_target)
+
+         # We need to redo saving the model now that we have potentially unflagged some data.
+         tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration),
+                     band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
+                     threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_curr'])+'Jy',
+                     savemodel='modelcolumn',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
+                     nterms=selfcal_library[target][band]['nterms'],
+                     field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], nfrms_multiplier=nfsnr_modifier, savemodel_only=True)
+
+         for vis in vislist:
             applycal_gaintable[vis]=[]
             applycal_spwmap[vis]=[]
             applycal_interpolate[vis]=[]

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -6,7 +6,8 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                    nsigma=5.0, imsize = None, cellsize = None, interactive = False, robust = 0.5, gain = 0.1, niter = 50000,\
                    cycleniter = 300, uvtaper = [], savemodel = 'none',gridder='standard', sidelobethreshold=3.0,smoothfactor=1.0,noisethreshold=5.0,\
                    lownoisethreshold=1.5,parallel=False,nterms=1,cyclefactor=3,uvrange='',threshold='0.0Jy',phasecenter='',\
-                   startmodel='',pblimit=0.1,pbmask=0.1,field='',datacolumn='',spw='',obstype='single-point',):
+                   startmodel='',pblimit=0.1,pbmask=0.1,field='',datacolumn='',spw='',obstype='single-point', \
+                   savemodel_only=False):
     """
     Wrapper for tclean with keywords set to values desired for the Large Program imaging
     See the CASA 6.1.1 documentation for tclean to get the definitions of all the parameters
@@ -72,41 +73,42 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
 
     if gridder=='mosaic' and startmodel!='':
        parallel=False
-    for ext in ['.image*', '.mask', '.model*', '.pb*', '.psf*', '.residual*', '.sumwt*','.gridwt*']:
-        os.system('rm -rf '+ imagename + ext)
-    tclean(vis= vis, 
-           imagename = imagename, 
-           field=field,
-           specmode = 'mfs', 
-           deconvolver = 'mtmfs',
-           scales = scales, 
-           gridder=gridder,
-           weighting='briggs', 
-           robust = robust,
-           gain = gain,
-           imsize = imsize,
-           cell = cellsize, 
-           smallscalebias = smallscalebias, #set to CASA's default of 0.6 unless manually changed
-           niter = niter, #we want to end on the threshold
-           interactive = interactive,
-           nsigma=nsigma,    
-           cycleniter = cycleniter,
-           cyclefactor = cyclefactor, 
-           uvtaper = uvtaper, 
-           savemodel = 'none',
-           mask=mask,
-           usemask=usemask,
-           sidelobethreshold=sidelobethreshold,
-           smoothfactor=smoothfactor,
-           pbmask=pbmask,
-           pblimit=pblimit,
-           nterms = nterms,
-           uvrange=uvrange,
-           threshold=threshold,
-           parallel=parallel,
-           phasecenter=phasecenter,
-           startmodel=startmodel,
-           datacolumn=datacolumn,spw=spw,wprojplanes=wprojplanes)
+    if not savemodel_only:
+        for ext in ['.image*', '.mask', '.model*', '.pb*', '.psf*', '.residual*', '.sumwt*','.gridwt*']:
+            os.system('rm -rf '+ imagename + ext)
+        tclean(vis= vis, 
+               imagename = imagename, 
+               field=field,
+               specmode = 'mfs', 
+               deconvolver = 'mtmfs',
+               scales = scales, 
+               gridder=gridder,
+               weighting='briggs', 
+               robust = robust,
+               gain = gain,
+               imsize = imsize,
+               cell = cellsize, 
+               smallscalebias = smallscalebias, #set to CASA's default of 0.6 unless manually changed
+               niter = niter, #we want to end on the threshold
+               interactive = interactive,
+               nsigma=nsigma,    
+               cycleniter = cycleniter,
+               cyclefactor = cyclefactor, 
+               uvtaper = uvtaper, 
+               savemodel = 'none',
+               mask=mask,
+               usemask=usemask,
+               sidelobethreshold=sidelobethreshold,
+               smoothfactor=smoothfactor,
+               pbmask=pbmask,
+               pblimit=pblimit,
+               nterms = nterms,
+               uvrange=uvrange,
+               threshold=threshold,
+               parallel=parallel,
+               phasecenter=phasecenter,
+               startmodel=startmodel,
+               datacolumn=datacolumn,spw=spw,wprojplanes=wprojplanes)
      #this step is a workaround a bug in tclean that doesn't always save the model during multiscale clean. See the "Known Issues" section for CASA 5.1.1 on NRAO's website
     if savemodel=='modelcolumn':
           print("")
@@ -138,6 +140,7 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                  pblimit=pblimit,
                  calcres = False,
                  calcpsf = False,
+                 restoration = False,
                  nterms = nterms,
                  uvrange=uvrange,
                  threshold=threshold,


### PR DESCRIPTION
tclean is run before unflagging to the initial state, and only sets the model column for unflagged data. Because some data get unflagged after this, they have model == 0, which can lead to problems with the gaincal solution. This fix runs tclean with the model column being filled *after* unflagging the data to get around this issue.

@r-xue, mentioning you to keep you in the loop in case this is relevant for your development of the pipeline version.