### PR TITLE
Run a full tclean for the _post image for each solint, and use that as a start for the next solint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+*.ms*
+*.log
+*.last
+*.g
+*.pre
+*.pickle
+*.tt*
+*.alpha*
+*.gridwt
+*.mask
+weblog
+
+.*.swp
+
+applycal_to_orig_MSes.py

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -56,7 +56,7 @@ delta_beam_thresh=0.05
 n_ants=get_n_ants(vislist)
 telescope=get_telescope(vislist[0])
 apply_cal_mode_default='calflag'
-full_tclean_post=True
+full_tclean_post=False
 rel_thresh_scaling='log10'  #can set to linear, log10, or loge (natural log)
 dividing_factor=-99.0  # number that the peak SNR is divided by to determine first clean threshold -99.0 uses default
                        # default is 40 for <8ghz and 15.0 for all other frequencies

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -670,6 +670,7 @@ for target in all_targets:
 
          ## Create post self-cal image using the model as a startmodel to evaluate how much selfcal helped
          ##
+         os.system('rm -rf '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post*')
          tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post',
                   band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
                   threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_curr'])+'Jy',

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -506,12 +506,14 @@ for target in all_targets:
                      savemodel='modelcolumn',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
                      nterms=selfcal_library[target][band]['nterms'],
                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
-         print('Pre selfcal assessemnt: '+target)
-         SNR,RMS=estimate_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0')
-         if telescope !='ACA':
-            SNR_NF,RMS_NF=estimate_near_field_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0')
-         else:
-            SNR_NF,RMS_NF=SNR,RMS
+
+         if not full_tclean_post:
+            print('Pre selfcal assessemnt: '+target)
+            SNR,RMS=estimate_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0')
+            if telescope !='ACA':
+               SNR_NF,RMS_NF=estimate_near_field_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0')
+            else:
+               SNR_NF,RMS_NF=SNR,RMS
 
          header=imhead(imagename=sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0')
 
@@ -647,6 +649,53 @@ for target in all_targets:
                      gaintable=applycal_gaintable[vis],\
                      interp=applycal_interpolate[vis], calwt=True,spwmap=applycal_spwmap[vis],\
                      applymode=applycal_mode[band][iteration],field=target,spw=selfcal_library[target][band][vis]['spws'])
+
+         ## Create post self-cal image using the model as a startmodel to evaluate how much selfcal helped
+         ##
+         if selfcal_library[target][band]['nterms']==1:
+            startmodel=[sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.model.tt0']
+         elif selfcal_library[target][band]['nterms']==2:
+            startmodel=[sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.model.tt0',sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.model.tt1']
+         if full_tclean_post:
+             tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post',
+                      band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
+                      threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_curr'])+'Jy',
+                      savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
+                      nterms=selfcal_library[target][band]['nterms'],
+                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
+         else:
+             tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post',
+                      band_properties,band,telescope=telescope,scales=[0], nsigma=0.0,\
+                      savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],nterms=selfcal_library[target][band]['nterms'],\
+                      niter=0,startmodel=startmodel,field=target,spw=selfcal_library[target][band]['spws_per_vis'],
+                      uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
+
+         ##
+         ## Do the assessment of the post- (and pre-) selfcal images.
+         ##
+         if full_tclean_post:
+            print('Pre selfcal assessemnt: '+target)
+            SNR,RMS=estimate_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0', \
+                    maskname=sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.mask')
+            if telescope !='ACA':
+               SNR_NF,RMS_NF=estimate_near_field_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0', \
+                       maskname=sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.mask')
+            else:
+               SNR_NF,RMS_NF=SNR,RMS
+
+         print('Post selfcal assessemnt: '+target)
+         #copy mask for use in post-selfcal SNR measurement
+         if not full_tclean_post:
+             os.system('cp -r '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.mask '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.mask')
+         post_SNR,post_RMS=estimate_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.image.tt0')
+         if telescope !='ACA':
+            post_SNR_NF,post_RMS_NF=estimate_near_field_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.image.tt0')
+         else:
+            post_SNR_NF,post_RMS_NF=post_SNR,post_RMS
+
+         if post_SNR > 500.0: # if S/N > 500, change nterms to 2 for best performance
+            selfcal_library[target][band]['nterms']=2
+
          for vis in vislist:
             ##
             ## record self cal results/details for this solint
@@ -669,37 +718,6 @@ for target in all_targets:
             selfcal_library[target][band][vis][solint]['intflux_pre'],selfcal_library[target][band][vis][solint]['e_intflux_pre']=get_intflux(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0',RMS)
             selfcal_library[target][band][vis][solint]['fallback']=fallback[vis]+''
             selfcal_library[target][band][vis][solint]['solmode']=solmode[band][iteration]+''
-         ## Create post self-cal image using the model as a startmodel to evaluate how much selfcal helped
-         ##
-         if selfcal_library[target][band]['nterms']==1:
-            startmodel=[sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.model.tt0']
-         elif selfcal_library[target][band]['nterms']==2:
-            startmodel=[sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.model.tt0',sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.model.tt1']
-         if full_tclean_post:
-             tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post',
-                      band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
-                      threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_curr'])+'Jy',
-                      savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
-                      nterms=selfcal_library[target][band]['nterms'],
-                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
-         else:
-             tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post',
-                      band_properties,band,telescope=telescope,scales=[0], nsigma=0.0,\
-                      savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],nterms=selfcal_library[target][band]['nterms'],\
-                      niter=0,startmodel=startmodel,field=target,spw=selfcal_library[target][band]['spws_per_vis'],
-                      uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
-         print('Post selfcal assessemnt: '+target)
-         #copy mask for use in post-selfcal SNR measurement
-         if not full_tclean_post:
-             os.system('cp -r '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.mask '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.mask')
-         post_SNR,post_RMS=estimate_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.image.tt0')
-         if post_SNR > 500.0: # if S/N > 500, change nterms to 2 for best performance
-            selfcal_library[target][band]['nterms']=2
-         if telescope !='ACA':
-            post_SNR_NF,post_RMS_NF=estimate_near_field_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.image.tt0')
-         else:
-            post_SNR_NF,post_RMS_NF=post_SNR,post_RMS
-         for vis in vislist:
             selfcal_library[target][band][vis][solint]['SNR_post']=post_SNR.copy()
             selfcal_library[target][band][vis][solint]['RMS_post']=post_RMS.copy()
             selfcal_library[target][band][vis][solint]['SNR_NF_post']=post_SNR_NF.copy()

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -56,6 +56,7 @@ delta_beam_thresh=0.05
 n_ants=get_n_ants(vislist)
 telescope=get_telescope(vislist[0])
 apply_cal_mode_default='calflag'
+full_tclean_post=True
 rel_thresh_scaling='log10'  #can set to linear, log10, or loge (natural log)
 dividing_factor=-99.0  # number that the peak SNR is divided by to determine first clean threshold -99.0 uses default
                        # default is 40 for <8ghz and 15.0 for all other frequencies
@@ -674,14 +675,23 @@ for target in all_targets:
             startmodel=[sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.model.tt0']
          elif selfcal_library[target][band]['nterms']==2:
             startmodel=[sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.model.tt0',sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.model.tt1']
-         tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post',
-                  band_properties,band,telescope=telescope,scales=[0], nsigma=0.0,\
-                  savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],nterms=selfcal_library[target][band]['nterms'],\
-                  niter=0,startmodel=startmodel,field=target,spw=selfcal_library[target][band]['spws_per_vis'],
-                  uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
+         if full_tclean_post:
+             tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post',
+                      band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
+                      threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_curr'])+'Jy',
+                      savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
+                      nterms=selfcal_library[target][band]['nterms'],
+                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
+         else:
+             tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post',
+                      band_properties,band,telescope=telescope,scales=[0], nsigma=0.0,\
+                      savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],nterms=selfcal_library[target][band]['nterms'],\
+                      niter=0,startmodel=startmodel,field=target,spw=selfcal_library[target][band]['spws_per_vis'],
+                      uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
          print('Post selfcal assessemnt: '+target)
          #copy mask for use in post-selfcal SNR measurement
-         os.system('cp -r '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.mask '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.mask')
+         if not full_tclean_post:
+             os.system('cp -r '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.mask '+sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.mask')
          post_SNR,post_RMS=estimate_SNR(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.image.tt0')
          if post_SNR > 500.0: # if S/N > 500, change nterms to 2 for best performance
             selfcal_library[target][band]['nterms']=2

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -500,12 +500,29 @@ for target in all_targets:
          ## set threshold based on RMS of initial image and lower if value becomes lower
          ## during selfcal by resetting 'RMS_curr' after the post-applycal evaluation
          ##
+         if full_tclean_post and selfcal_library[target][band]['final_solint'] != 'None':
+             prev_solint = selfcal_library[target][band]['final_solint']
+             prev_iteration = selfcal_library[target][band][vislist[0]][prev_solint]['iteration']
+
+             nterms_changed = len(glob.glob(sani_target+'_'+band+'_'+prev_solint+'_'+str(prev_iteration)+"_post.model.tt*")) < 
+                    selfcal_library[target][band]['nterms']
+
+             if nterms_changed:
+                 resume = False
+             else:
+                 resume = True
+                 files = glob.glob(sani_target+'_'+band+'_'+prev_solint+'_'+str(prev_iteration)+"_post.*")
+                 for f in files:
+                     os.system("cp -r "+f+" "+f.replace(prev_solint+"_"+str(prev_iteration)+"_post", solint+'_'+str(iteration)))
+         else:
+             resume = False
+
          tclean_wrapper(vislist,sani_target+'_'+band+'_'+solint+'_'+str(iteration),
                      band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
                      threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_curr'])+'Jy',
                      savemodel='modelcolumn',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
                      nterms=selfcal_library[target][band]['nterms'],
-                     field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
+                     field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], resume=resume)
 
          if not full_tclean_post:
             print('Pre selfcal assessemnt: '+target)

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -6,7 +6,8 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                    nsigma=5.0, imsize = None, cellsize = None, interactive = False, robust = 0.5, gain = 0.1, niter = 50000,\
                    cycleniter = 300, uvtaper = [], savemodel = 'none',gridder='standard', sidelobethreshold=3.0,smoothfactor=1.0,noisethreshold=5.0,\
                    lownoisethreshold=1.5,parallel=False,nterms=1,cyclefactor=3,uvrange='',threshold='0.0Jy',phasecenter='',\
-                   startmodel='',pblimit=0.1,pbmask=0.1,field='',datacolumn='',spw='',obstype='single-point',):
+                   startmodel='',pblimit=0.1,pbmask=0.1,field='',datacolumn='',spw='',obstype='single-point',\
+                   resume=False):
     """
     Wrapper for tclean with keywords set to values desired for the Large Program imaging
     See the CASA 6.1.1 documentation for tclean to get the definitions of all the parameters
@@ -72,8 +73,9 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
 
     if gridder=='mosaic' and startmodel!='':
        parallel=False
-    for ext in ['.image*', '.mask', '.model*', '.pb*', '.psf*', '.residual*', '.sumwt*','.gridwt*']:
-        os.system('rm -rf '+ imagename + ext)
+    if not resume:
+        for ext in ['.image*', '.mask', '.model*', '.pb*', '.psf*', '.residual*', '.sumwt*','.gridwt*']:
+            os.system('rm -rf '+ imagename + ext)
     tclean(vis= vis, 
            imagename = imagename, 
            field=field,


### PR DESCRIPTION
Initially auto_selfcal was using the model from the _pre image to more quickly generate the _post image after calibrations were applied. This was computationally more efficient, but could occasionally lead to poor subtractions and large residuals in the _post image. This merge has the code now running a full tclean for the _post image. To get back some of the computational efficiency, it uses the _post image as a starting point for the _pre image for the next solution interval. (This was initially an option that could be turned on, but has now been made standard - is this ok?).

One quick question to check - it should always be the case that the threshold for a subsequent solint is <= the threshold for the previous solint, right? Want to avoid cases where somehow the threshold goes up and so the _pre image is over cleaned compared with the _post image, if that could happen.

Github is also telling me this can't be automatically merged, not entirely sure why but will have to sort that out. In the meantime, the full_tclean_post branch in my fork can be used for testing.

Mentioning @r-xue in case this becomes relevant for the pipelin version.