### PR TITLE
Fix cropping when images are wider than high

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1675,7 +1675,7 @@ def plot_image(filename,outname,min=None,max=None):
    else:
       remainder=width-height
       trim_amount=int(remainder/2.0)
-      im1=im.crop((trim_amount,height-1,width,width-trim_amount-1,0))
+      im1=im.crop((trim_amount,0,width-trim_amount-1,height-1))
    im1.save(outname)
 
 def get_flagged_solns_per_ant(gaintable,vis):


### PR DESCRIPTION
This has been a bit of a thorn in my side, so finally getting around to creating a fix in a unique branch so it can be merged on its own. Should fix issues cropping when casaviewer creates images that are wider than they are high.