### PR TITLE
Fix theoretical sensitivity

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -246,10 +246,11 @@ for target in all_targets:
    dirty_SNR,dirty_RMS=estimate_SNR(sani_target+'_'+band+'_dirty.image.tt0')
    dr_mod=1.0
    if telescope =='ALMA' or telescope =='ACA':
-      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
+      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
       dr_mod=get_dr_correction(telescope,dirty_SNR*dirty_RMS,sensitivity,vislist)
       sensitivity_nomod=sensitivity.copy()
       print('DR modifier: ',dr_mod)
+      sys.exit(0)
    if not os.path.exists(sani_target+'_'+band+'_initial.image.tt0'):
       if telescope=='ALMA' or telescope =='ACA':
          sensitivity=sensitivity*dr_mod   # apply DR modifier
@@ -355,7 +356,7 @@ if check_all_spws:
             dirty_SNR,dirty_RMS=estimate_SNR(sani_target+'_'+band+'_'+spw+'_dirty.image.tt0')
             if not os.path.exists(sani_target+'_'+band+'_'+spw+'_initial.image.tt0'):
                if telescope=='ALMA' or telescope =='ACA':
-                  sensitivity=get_sensitivity(vislist,selfcal_library[target][band],spw,spw=np.array([int(spw)]),imsize=imsize[band],cellsize=cellsize[band])
+                  sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,spw,spw=np.array([int(spw)]),imsize=imsize[band],cellsize=cellsize[band])
                   dr_mod=1.0
                   dr_mod=get_dr_correction(telescope,dirty_SNR*dirty_RMS,sensitivity,vislist)
                   print('DR modifier: ',dr_mod,'SPW: ',spw)
@@ -462,7 +463,7 @@ for target in all_targets:
    if n_ap_solints > 0:
       selfcal_library[target][band]['nsigma']
    if telescope=='ALMA' or telescope =='ACA': #or ('VLA' in telescope) 
-      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
+      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
       if band =='Band_9' or band == 'Band_10':   # adjust for DSB noise increase
          sensitivity=sensitivity*4.0 
       if ('VLA' in telescope):
@@ -855,7 +856,7 @@ for target in all_targets:
    vislist=selfcal_library[target][band]['vislist'].copy()
    ## omit DR modifiers here since we should have increased DR significantly
    if telescope=='ALMA' or telescope =='ACA':
-      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
+      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
       dr_mod=1.0
       if not selfcal_library[target][band]['SC_success']: # fetch the DR modifier if selfcal failed on source
          dr_mod=get_dr_correction(telescope,selfcal_library[target][band]['SNR_dirty']*selfcal_library[target][band]['RMS_dirty'],sensitivity,vislist)
@@ -919,7 +920,7 @@ if check_all_spws:
    ## omit DR modifiers here since we should have increased DR significantly
             if not os.path.exists(sani_target+'_'+band+'_'+spw+'_final.image.tt0'):
                if telescope=='ALMA' or telescope =='ACA':
-                  sensitivity=get_sensitivity(vislist,selfcal_library[target][band],spw,spw=np.array([int(spw)]),imsize=imsize[band],cellsize=cellsize[band])
+                  sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,spw,spw=np.array([int(spw)]),imsize=imsize[band],cellsize=cellsize[band])
                   dr_mod=1.0
                   if not selfcal_library[target][band]['SC_success']: # fetch the DR modifier if selfcal failed on source
                      dr_mod=get_dr_correction(telescope,selfcal_library[target][band]['SNR_dirty']*selfcal_library[target][band]['RMS_dirty'],sensitivity,vislist)

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -250,7 +250,6 @@ for target in all_targets:
       dr_mod=get_dr_correction(telescope,dirty_SNR*dirty_RMS,sensitivity,vislist)
       sensitivity_nomod=sensitivity.copy()
       print('DR modifier: ',dr_mod)
-      sys.exit(0)
    if not os.path.exists(sani_target+'_'+band+'_initial.image.tt0'):
       if telescope=='ALMA' or telescope =='ACA':
          sensitivity=sensitivity*dr_mod   # apply DR modifier

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1051,9 +1051,15 @@ def get_SNR_self_update(all_targets,band,vislist,selfcal_library,n_ant,solint_cu
 
 def get_sensitivity(vislist,selfcal_library,field='',specmode='mfs',spwstring='',spw=[],chan=0,cellsize='0.025arcsec',imsize=1600,robust=0.5,uvtaper=''):
    scalefactor=1.0
+   maxspws=0
+   maxspwvis=''
    for vis in vislist:
       im.selectvis(vis=vis,field=field,spw=selfcal_library[vis]['spws'])
-   im.defineimage(mode=specmode,stokes='I',spw=selfcal_library[vis]['spwsarray'],cellx=cellsize,celly=cellsize,nx=imsize,ny=imsize)  
+      # Also figure out which vis has the max # of spws
+      if selfcal_library[vis]['n_spws'] >= maxspws:
+          maxspws=selfcal_library[vis]['n_spws']
+          maxspwvis=vis+''
+   im.defineimage(mode=specmode,stokes='I',spw=selfcal_library[maxspwvis]['spwsarray'],cellx=cellsize,celly=cellsize,nx=imsize,ny=imsize)  
    im.weight(type='briggs',robust=robust)  
    if uvtaper != '':
       if 'klambda' in uvtaper:

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1049,47 +1049,34 @@ def get_SNR_self_update(all_targets,band,vislist,selfcal_library,n_ant,solint_cu
          solint_snr[target][band][solint_next]=selfcal_library[target][band][vislist[0]][solint_curr]['SNR_post']/((n_ant-3)**0.5*(selfcal_library[target][band]['Total_TOS']/solint_float)**0.5)
 
 
-def get_sensitivity(vislist,selfcal_library,specmode='mfs',spwstring='',spw=[],chan=0,cellsize='0.025arcsec',imsize=1600,robust=0.5,uvtaper=''):
-   sensitivities=np.zeros(len(vislist))
-   TOS=np.zeros(len(vislist))
-   counter=0
+def get_sensitivity(vislist,selfcal_library,field='',specmode='mfs',spwstring='',spw=[],chan=0,cellsize='0.025arcsec',imsize=1600,robust=0.5,uvtaper=''):
    scalefactor=1.0
    for vis in vislist:
-      im.open(vis)
-      im.selectvis(field='',spw=spwstring)
-      im.defineimage(mode=specmode,stokes='I',spw=spw,cellx=cellsize,celly=cellsize,nx=imsize,ny=imsize)  
-      im.weight(type='briggs',robust=robust)  
-      if uvtaper != '':
-         if 'klambda' in uvtaper:
-            uvtaper=uvtaper.replace('klambda','')
-            uvtaperflt=float(uvtaper)
-            bmaj=str(206.0/uvtaperflt)+'arcsec'
-            bmin=bmaj
-            bpa='0.0deg'
-         if 'arcsec' in uvtaper:
-            bmaj=uvtaper
-            bmin=uvtaper
-            bpa='0.0deg'
-         print('uvtaper: '+bmaj+' '+bmin+' '+bpa)
-         im.filter(type='gaussian', bmaj=bmaj, bmin=bmin, bpa=bpa)
-      try:
-          sens=im.apparentsens()
-      except:
-          print('#')
-          print('# Sensisitivity Calculation failed for '+vis)
-          print('# Continuing to next MS') 
-          print('# Data in this spw/MS may be flagged')
-          print('#')
-          continue
-      #print(sens)
-      #print(vis,'Briggs Sensitivity = ', sens[1])
-      #print(vis,'Relative to Natural Weighting = ', sens[2])  
-      sensitivities[counter]=sens[1]*scalefactor
-      TOS[counter]=selfcal_library[vis]['TOS']
-      counter+=1
-   #estsens=np.sum(sensitivities)/float(counter)/(float(counter))**0.5
-   #print(estsens)
-   estsens=np.sum(sensitivities*TOS)/np.sum(TOS)
+      im.selectvis(vis=vis,field=field,spw=selfcal_library[vis]['spws'])
+   im.defineimage(mode=specmode,stokes='I',spw=selfcal_library[vis]['spwsarray'],cellx=cellsize,celly=cellsize,nx=imsize,ny=imsize)  
+   im.weight(type='briggs',robust=robust)  
+   if uvtaper != '':
+      if 'klambda' in uvtaper:
+         uvtaper=uvtaper.replace('klambda','')
+         uvtaperflt=float(uvtaper)
+         bmaj=str(206.0/uvtaperflt)+'arcsec'
+         bmin=bmaj
+         bpa='0.0deg'
+      if 'arcsec' in uvtaper:
+         bmaj=uvtaper
+         bmin=uvtaper
+         bpa='0.0deg'
+      print('uvtaper: '+bmaj+' '+bmin+' '+bpa)
+      im.filter(type='gaussian', bmaj=bmaj, bmin=bmin, bpa=bpa)
+   try:
+       estsens=np.float64(im.apparentsens()[1])
+   except:
+       print('#')
+       print('# Sensisitivity Calculation failed for '+vis)
+       print('# Continuing to next MS') 
+       print('# Data in this spw/MS may be flagged')
+       print('#')
+       sys.exit(0)
    print('Estimated Sensitivity: ',estsens)
    return estsens
 


### PR DESCRIPTION
This PR fixes the `get_sensitivity` function to properly calculate the theoretical sensitivity on a per-source, all-EB basis by defining an image over all of the EBs at once and running just one sensitivity estimate. (As a note, it was previously averaging the per-EB sensitivities rather than doing something like sensitivity / N**0.5, but this was typically balanced by the fact that the # of EBs ~ # of targets, and it was calculating the sensitivity over all targets).

@jjtobin, one note: on line 1056, the `im.defineimage` call takes a list of SPWs. As this is now being done for *all* EBs at once, we might need to invoke your fixes for `maxspwvis` so that cases where there are slightly different numbers of spws across different EBs get handled properly. I don't know if you have time to test that out... but I'll look into adding that fix this afternoon, so it may be worth holding off merging this until then.