### PR TITLE
Create script to split calibrated_final.ms into individual EBs

### DIFF
--- a/split_calibrated_final.py
+++ b/split_calibrated_final.py
@@ -1,0 +1,12 @@
+from casatools import msmetadata as msmdtool
+
+msmd = msmdtool()
+
+msmd.open("calibrated_final.ms")
+for i in range(msmd.nobservations()):
+    split("calibrated_final.ms", outputvis=msmd.schedule(i)[1].split(" ")[1].replace("/","_").replace(":","_")+"_targets.ms", \
+            observation=i, intent="*OBSERVE_TARGET*", \
+            spw=','.join(msmd.spwsforscan(msmd.scansforintent("*OBSERVE_TARGET*", obsid=i)[0], obsid=i).astype(str)), \
+            antenna=','.join(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*", obsid=i)[0], obsid=i).astype(str)), \
+            datacolumn="data")
+msmd.close()


### PR DESCRIPTION
I just had to deal with a number of calibrated_final.ms files and decided to spend a small amount of time figuring out how to split them automatically rather than doing it all manually. I figure that this could presumably be useful to other users of the code, so am adding it to the repo for others to make use of.

As a quick note, I haven't formally tested it on a  file yet, I originally wrote it in an interactive CASA session and copied and pasted, so I'll try to do that when I get a chance.