### PR TITLE
Don't copy nearfield mask for use with pre image of next solint

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -552,6 +552,8 @@ for target in all_targets:
                  resume = True
                  files = glob.glob(sani_target+'_'+band+'_'+prev_solint+'_'+str(prev_iteration)+"_post.*")
                  for f in files:
+                     if 'nearfield' in f:
+                         continue
                      os.system("cp -r "+f+" "+f.replace(prev_solint+"_"+str(prev_iteration)+"_post", solint+'_'+str(iteration)))
          else:
              resume = False


### PR DESCRIPTION
One additional fix to ensure that the nearfield mask is stored properly after being created.