### PR TITLE
PIPE-1921: Catch instances where the pre-solint mask is not generated and so the model is empty

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -566,6 +566,12 @@ for target in all_targets:
                      nterms=selfcal_library[target][band]['nterms'],
                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], nfrms_multiplier=nfsnr_modifier, resume=resume)
 
+         # Check that a mask was actually created, because if not the model will be empty and gaincal will do bad things and the 
+         # code will break.
+         if not checkmask(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0'):
+             selfcal_library[target][band]['Stop_Reason'] = 'Empty model for solint '+solint
+             break # breakout of loop because the model is empty and gaincal will therefore fail
+
          header=imhead(imagename=sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0')
 
          if iteration == 0:


### PR DESCRIPTION
Fixes instances where a pre-solint image has an empty mask leading to an empty model and subsequent gaincal failures.

@r-xue, this is the fix for PIPE-1921. Its a fairly minor addition to the code to just check whether the mask is empty and to exit cleanly if so.

As a note, it doesn't put any information into the per-solint details table for the given solint, it just reports that the stop reason was "Empty model for solint <solint>'. This is because it would have been much more complicated to add the relevant conditions on the various entries in the table to only show if there's a post image, but I think this is ok because it doesn't formally do the interval. So it isn't entirely not sensible to report this way.

@jjtobin, probably good to hold off on merging until @r-xue as this merged into the pipeline version and all is working ok?