### PR TITLE
get_intflux should return results even if there is no mask.

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -951,9 +951,13 @@ def get_intflux(imagename,rms,maskname=None):
    if maskname is None:
       maskname=imagename.replace('image.tt0','mask')
    imagestats=imstat(imagename=imagename,mask=maskname)
-   flux=imagestats['flux'][0]
-   n_beams=imagestats['npts'][0]/pix_per_beam
-   e_flux=(n_beams)**0.5*rms
+   if len(imagestats['flux']) > 0:
+       flux=imagestats['flux'][0]
+       n_beams=imagestats['npts'][0]/pix_per_beam
+       e_flux=(n_beams)**0.5*rms
+   else:
+       flux = 0.
+       e_flux = rms
    return flux,e_flux
 
 def get_n_ants(vislist):


### PR DESCRIPTION
In the event that there is no mask, get_intflux breaks (per PIPE-1890 in the pipeline version). This was fixed in my fork and on the pipeline version, but not in your main, @jjtobin. As this has become an issue for a dataset that I'm testing, I'm merging it to your main for consistency with the pipeline version.

@r-xue - just a quick note that you'll see this show up in the PR you are monitoring for changes, but it is already fixed in pipeline in PIPE-1890.