### PR TITLE
Ensure get_sensitivity doesn't continue stacking MS files for repeated calls.

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -903,6 +903,7 @@ def get_sensitivity(vislist,selfcal_library,field='',specmode='mfs',spwstring=''
        print('#')
        sys.exit(0)
    print('Estimated Sensitivity: ',estsens)
+   im.close()
    return estsens
 
 


### PR DESCRIPTION
Because im.close() wasn't being called, repeated calls of get_sensitivity would continue to add on to the already selected visibilities for calculating sensitivity, and therefore get the wrong answer. This is now fixed by making sure to close the imager tool at the end.