### PR TITLE
Fix bug in cont.dat matching when 0 is a valid spw

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1076,6 +1076,7 @@ def flagchannels_from_contdotdat(vis,target,spwsarray,vislist,spwvisref,contdotd
         msmd.close()
         # must directly cast to int, otherwise the CASA tool call does not like numpy.uint64
         #loop through returned spws to see which is in the spw array rather than assuming, because assumptions be damned
+        trans_spw = -1
         for check_spw in spws[spwname]:
            matching_index=np.where(check_spw == spwsarray)
            if len(matching_index[0]) == 0:
@@ -1083,7 +1084,7 @@ def flagchannels_from_contdotdat(vis,target,spwsarray,vislist,spwvisref,contdotd
            else:
               trans_spw=check_spw
               break
-        if trans_spw==0:
+        if trans_spw==-1:
            print('COULD NOT DETERMINE SPW MAPPING FOR CONT.DAT, PROCEEDING WITHOUT FLAGGING FOR '+vis)
            return ''
         #trans_spw=int(np.max(spws[spwname])) # assume higher number spw is the correct one, generally true with ALMA data structure


### PR DESCRIPTION
In the event that 0 is a valid spw for cont.dat, there is a bug in the cont.dat matching that will lead to the code thinking it cant match and will not flag anything (and subsequently breaks for some reason). This PR fixes that by setting the "not found" spw to -1, which should never be a valid spw.