### PR TITLE
Fix problems that occur when cont.dat happens to be missing some targets

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -336,7 +336,7 @@ for target in all_targets:
          selfcal_library[target][band][vis]['total_effective_bandwidth']=0.0
          if len(spw_effective_bandwidths_dict[vis].keys()) != len(spw_bandwidths_dict[vis].keys()):
             print('cont.dat does not contain all spws; falling back to total bandwidth')
-            for spw in spw_bandwidths[vis].keys():
+            for spw in spw_bandwidths_dict[vis].keys():
                if spw not in spw_effective_bandwidths_dict[vis].keys():
                   spw_effective_bandwidths_dict[vis][spw]=spw_bandwidths_dict[vis][spw]
 
@@ -1084,6 +1084,8 @@ if casaversion[0]>=6 and casaversion[1]>=5 and casaversion[2]>=2:   # new uvcont
          sani_target=sanitize_string(target)
          for band in selfcal_library[target].keys():
             contdotdat = parse_contdotdat('cont.dat',target)
+            if len(contdotdat) == 0:
+                selfcal_library[target][band]['Found_contdotdat'] = False
             spwvisref=get_spwnum_refvis(vislist,target,contdotdat,spwsarray_dict)
             for vis in vislist:
                msmd.open(vis)
@@ -1108,6 +1110,8 @@ if casaversion[0]>=6 and casaversion[1]<=5 and casaversion[2]<2:   # old uvconts
          sani_target=sanitize_string(target)
          for band in selfcal_library[target].keys():
             contdotdat = parse_contdotdat('cont.dat',target)
+            if len(contdotdat) == 0:
+                selfcal_library[target][band]['Found_contdotdat'] = False
             spwvisref=get_spwnum_refvis(vislist,target,contdotdat,spwsarray_dict)
             for vis in vislist:      
                contdot_dat_flagchannels_string = flagchannels_from_contdotdat(vis.replace('.selfcal',''),target,spwsarray_dict[vis],vislist,spwvisref,contdotdat,return_contfit_range=True)

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -1075,7 +1075,7 @@ for target in all_targets:
 applyCalOut.close()
 
 casaversion=casatasks.version()
-if casaversion[0]>=6 and (casaversion[1]>5 or (casaversion[1]==5 and casaversion[2]>=2):   # new uvcontsub format only works in CASA >=6.5.2
+if casaversion[0]>6 or (casaversion[0]==6 and (casaversion[1]>5 or (casaversion[1]==5 and casaversion[2]>=2):   # new uvcontsub format only works in CASA >=6.5.2
    if os.path.exists("cont.dat"):
       contsub_dict={}
       for vis in vislist:  

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -1075,7 +1075,7 @@ for target in all_targets:
 applyCalOut.close()
 
 casaversion=casatasks.version()
-if casaversion[0]>=6 and casaversion[1]>=5 and casaversion[2]>=2:   # new uvcontsub format only works in CASA >=6.5.2
+if casaversion[0]>=6 and (casaversion[1]>5 or (casaversion[1]==5 and casaversion[2]>=2):   # new uvcontsub format only works in CASA >=6.5.2
    if os.path.exists("cont.dat"):
       contsub_dict={}
       for vis in vislist:  
@@ -1101,7 +1101,7 @@ if casaversion[0]>=6 and casaversion[1]>=5 and casaversion[2]>=2:   # new uvcont
          uvcontsubOut.writelines(line)
       uvcontsubOut.close()
 
-if casaversion[0]>=6 and casaversion[1]<=5 and casaversion[2]<2:   # old uvcontsub formatting, requires splitting out per target, new one is much better
+else:   # old uvcontsub formatting, requires splitting out per target, new one is much better
    if os.path.exists("cont.dat"):
       uvcontsubOut=open('uvcontsub_orig_MSes_old.py','w')
       line='import os\n'

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -1074,23 +1074,47 @@ for target in all_targets:
 
 applyCalOut.close()
 
+casaversion=casatasks.version()
+if casaversion[0]>=6 and casaversion[1]>=5 and casaversion[2]>=2:   # new uvcontsub format only works in CASA >=6.5.2
+   if os.path.exists("cont.dat"):
+      contsub_dict={}
+      for vis in vislist:  
+         contsub_dict[vis]={}  
+      for target in all_targets:
+         sani_target=sanitize_string(target)
+         for band in selfcal_library[target].keys():
+            contdotdat = parse_contdotdat('cont.dat',target)
+            spwvisref=get_spwnum_refvis(vislist,target,contdotdat,spwsarray_dict)
+            for vis in vislist:
+               msmd.open(vis)
+               field_num_array=msmd.fieldsforname(target)
+               msmd.close()
+               for fieldnum in field_num_array:
+                  contsub_dict[vis][str(fieldnum)]=get_fitspw_dict(vis.replace('.selfcal',''),target,spwsarray_dict[vis],vislist,spwvisref,contdotdat)
+                  print(contsub_dict[vis][str(fieldnum)])
+      print(contsub_dict)
+      uvcontsubOut=open('uvcontsub_orig_MSes.py','w')
+      for vis in vislist:  
+         line='uvcontsub(vis="'+vis.replace('.selfcal','')+'", spw="'+spwstring_dict[vis]+'",fitspec='+str(contsub_dict[vis])+', outputvis="'+vis.replace('.selfcal','').replace('.ms','.contsub.ms')+'",datacolumn="corrected")\n'
+         uvcontsubOut.writelines(line)
+      uvcontsubOut.close()
 
-if os.path.exists("cont.dat"):
-   uvcontsubOut=open('uvcontsub_orig_MSes.py','w')
-   line='import os\n'
-   uvcontsubOut.writelines(line)
-   for target in all_targets:
-      sani_target=sanitize_string(target)
-      for band in selfcal_library[target].keys():
-         contdotdat = parse_contdotdat('cont.dat',all_targets[0])
-         spwvisref=get_spwnum_refvis(vislist,all_targets[0],contdotdat,spwsarray_dict)
-         for vis in vislist:      
-            contdot_dat_flagchannels_string = flagchannels_from_contdotdat(vis.replace('.selfcal',''),target,selfcal_library[target][band][vis]['spwsarray'],vislist,spwvisref,contdotdat)[:-2]
-            line='uvcontsub(vis="'+vis.replace('.selfcal','')+'",field="'+target+'", spw="'+selfcal_library[target][band][vis]['spws']+'",fitspw="'+contdot_dat_flagchannels_string+'",excludechans=True, combine="spw")\n'
-            uvcontsubOut.writelines(line)
-            line='os.system("mv '+vis.replace('.selfcal','')+'.contsub '+sani_target+'_'+vis+'.contsub")\n'
-            uvcontsubOut.writelines(line)
-   uvcontsubOut.close()
+if casaversion[0]>=6 and casaversion[1]<=5 and casaversion[2]<2:   # old uvcontsub formatting, requires splitting out per target, new one is much better
+   if os.path.exists("cont.dat"):
+      uvcontsubOut=open('uvcontsub_orig_MSes_old.py','w')
+      line='import os\n'
+      uvcontsubOut.writelines(line)
+      for target in all_targets:
+         sani_target=sanitize_string(target)
+         for band in selfcal_library[target].keys():
+            contdotdat = parse_contdotdat('cont.dat',target)
+            spwvisref=get_spwnum_refvis(vislist,target,contdotdat,spwsarray_dict)
+            for vis in vislist:      
+               contdot_dat_flagchannels_string = flagchannels_from_contdotdat(vis.replace('.selfcal',''),target,spwsarray_dict[vis],vislist,spwvisref,contdotdat,return_contfit_range=True)
+               line='uvcontsub(vis="'+vis.replace('.selfcal','')+'", outputvis="'+sani_target+'_'+vis.replace('.selfcal',''.replace('.ms','.contsub.ms'))+'",field="'+target+'", spw="'+spwstring_dict[vis]+'",fitspec="'+contdot_dat_flagchannels_string+'", combine="spw")\n'
+               uvcontsubOut.writelines(line)
+      uvcontsubOut.close()
+
 
 
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1863,7 +1863,7 @@ def generate_weblog(sclib,solints,bands):
                continue
          htmlOut.writelines('Final Successful solint: '+str(sclib[target][band]['final_solint'])+'<br><br>\n')
          if 'Found_contdotdat' in sclib[target][band]:
-             htmlOut.write('<font color="red">WARNING:</font> No cont.dat entry found for target "+target+", this likely indicates that hif_findcont was mitigated. We suggest you re-run findcont without mitigation.<br><br>')
+             htmlOut.write('<font color="red">WARNING:</font> No cont.dat entry found for target '+target+', this likely indicates that hif_findcont was mitigated. We suggest you re-run findcont without mitigation.<br><br>')
          # Summary table for before/after SC
          render_summary_table(htmlOut,sclib,target,band)
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1175,6 +1175,10 @@ def get_fitspw_dict(vis,target,spwsarray,vislist,spwvisref,contdotdat,fitorder=1
                flagchannels_string += '%d~%d;' % (chans[i], chans[i+1])
             fitspw_dict[str(trans_spw)]['chan']=flagchannels_string[:-1]
 
+    if len(fitspw_dict) == 0:
+        print("WARNING: No entry found in cont.dat for target "+target+", fitting all channels for continuum range.")
+        fitspw_dict[','.join(spwsarray.astype(str))] = ''
+
     return fitspw_dict
 
 def get_spw_chanwidths(vis,spwarray):
@@ -2372,6 +2376,10 @@ def flag_spectral_lines(vislist,all_targets,spwsarray_dict):
          flagmanager(vis=vis,mode='restore',versionname='before_line_flags')
       for target in all_targets:
          contdotdat = parse_contdotdat('cont.dat',target)
+         if len(contdotdat) == 0:
+             print("WARNING: No cont.dat entry found for target "+target+", this likely indicates that hif_findcont was mitigated. We suggest you re-run findcont without mitigation.")
+             print("No flagging will be done for target "+target)
+             continue
          contdot_dat_flagchannels_string = flagchannels_from_contdotdat(vis,target,spwsarray_dict[vis],vislist,spwvisref,contdotdat)
          flagdata(vis=vis, mode='manual', spw=contdot_dat_flagchannels_string[:-2], flagbackup=False, field = target)
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1862,6 +1862,8 @@ def generate_weblog(sclib,solints,bands):
                render_summary_table(htmlOut,sclib,target,band)
                continue
          htmlOut.writelines('Final Successful solint: '+str(sclib[target][band]['final_solint'])+'<br><br>\n')
+         if 'Found_contdotdat' in sclib[target][band]:
+             htmlout.write("WARNING: No cont.dat entry found for target "+target+", this likely indicates that hif_findcont was mitigated. We suggest you re-run findcont without mitigation.<br><br>")
          # Summary table for before/after SC
          render_summary_table(htmlOut,sclib,target,band)
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1863,7 +1863,7 @@ def generate_weblog(sclib,solints,bands):
                continue
          htmlOut.writelines('Final Successful solint: '+str(sclib[target][band]['final_solint'])+'<br><br>\n')
          if 'Found_contdotdat' in sclib[target][band]:
-             htmlout.write("WARNING: No cont.dat entry found for target "+target+", this likely indicates that hif_findcont was mitigated. We suggest you re-run findcont without mitigation.<br><br>")
+             htmlOut.write("WARNING: No cont.dat entry found for target "+target+", this likely indicates that hif_findcont was mitigated. We suggest you re-run findcont without mitigation.<br><br>")
          # Summary table for before/after SC
          render_summary_table(htmlOut,sclib,target,band)
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1863,7 +1863,7 @@ def generate_weblog(sclib,solints,bands):
                continue
          htmlOut.writelines('Final Successful solint: '+str(sclib[target][band]['final_solint'])+'<br><br>\n')
          if 'Found_contdotdat' in sclib[target][band]:
-             htmlOut.write("WARNING: No cont.dat entry found for target "+target+", this likely indicates that hif_findcont was mitigated. We suggest you re-run findcont without mitigation.<br><br>")
+             htmlOut.write('<font color="red">WARNING:</font> No cont.dat entry found for target "+target+", this likely indicates that hif_findcont was mitigated. We suggest you re-run findcont without mitigation.<br><br>')
          # Summary table for before/after SC
          render_summary_table(htmlOut,sclib,target,band)
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1050,7 +1050,7 @@ def get_spwnum_refvis(vislist,target,contdotdat,spwsarray_dict):
    visref=vislist[np.argmin(score)]            
    return visref
 
-def flagchannels_from_contdotdat(vis,target,spwsarray,vislist,spwvisref,contdotdat):
+def flagchannels_from_contdotdat(vis,target,spwsarray,vislist,spwvisref,contdotdat,return_contfit_range=False):
     """
     Generates a string with the list of lines identified by the cont.dat file from the ALMA pipeline, that need to be flagged.
 
@@ -1108,15 +1108,74 @@ def flagchannels_from_contdotdat(vis,target,spwsarray,vislist,spwvisref,contdotd
             """
 
         chans = np.sort(chans)
-
-        flagchannels_string += '0~%d;' % (chans[0])
-        for i in range(1,chans.size-1,2):
-            flagchannels_string += '%d~%d;' % (chans[i], chans[i+1])
-        flagchannels_string += '%d~%d, ' % (chans[-1], nchan-1)
-
-    print("# Flagchannels input string for %s in %s from cont.dat file: \'%s\'" % (target, vis, flagchannels_string))
-
+        if not return_contfit_range:
+           flagchannels_string += '0~%d;' % (chans[0])
+           for i in range(1,chans.size-1,2):
+               flagchannels_string += '%d~%d;' % (chans[i], chans[i+1])
+           flagchannels_string += '%d~%d, ' % (chans[-1], nchan-1)
+        else:
+           for i in range(0,chans.size-1,2):
+               flagchannels_string += '%d~%d;' % (chans[i], chans[i+1])
+           flagchannels_string=flagchannels_string[:-1]+ ',' 
+    if not return_contfit_range:
+       print("# Flagchannels input string for %s in %s from cont.dat file: \'%s\'" % (target, vis, flagchannels_string))
+    else:    
+       flagchannels_string=flagchannels_string[:-1]
+       print("# Cont range string for %s in %s from cont.dat file: \'%s\'" % (target, vis, flagchannels_string))
     return flagchannels_string
+
+def get_fitspw_dict(vis,target,spwsarray,vislist,spwvisref,contdotdat,fitorder=1):
+    """
+    Generates a string with the list of lines identified by the cont.dat file from the ALMA pipeline, that need to be flagged.
+
+    Parameters
+    ==========
+    ms_dict: Dictionary of information about measurement set
+
+    Returns
+    =======
+    String of channels to be flagged, in a format that can be passed to the spw parameter in CASA's flagdata task. 
+    """
+
+    fitspw_dict = {}
+    #moved out of function to not for each MS for efficiency
+    #contdotdat = parse_contdotdat('cont.dat',target)
+    #spwvisref=get_spwnum_refvis(vislist,target,contdotdat,spwsarray)
+    for j,spw in enumerate(contdotdat):
+        msmd.open(spwvisref)
+        spwname=msmd.namesforspws(spw)[0]
+        msmd.close()
+        msmd.open(vis)
+        spws=msmd.spwsfornames(spwname)
+        msmd.close()
+        # must directly cast to int, otherwise the CASA tool call does not like numpy.uint64
+        trans_spw=int(np.max(spws[spwname])) # assume higher number spw is the correct one, generally true with ALMA data structure
+        #flagchannels_string += '%d:' % (trans_spw)
+        tb.open(vis+'/SPECTRAL_WINDOW')
+        nchan = tb.getcol('CHAN_FREQ', startrow = trans_spw, nrow = 1).size
+        tb.close()
+
+        chans = np.array([])
+        for k in range(contdotdat[spw].shape[0]):
+            print(trans_spw, contdotdat[spw][k])
+
+            chans = np.concatenate((LSRKfreq_to_chan(vis, target, trans_spw, contdotdat[spw][k],spwsarray),chans))
+
+            """
+            if flagchannels_string == '':
+                flagchannels_string+='%d:%d~%d' % (spw, np.min([chans[0], chans[1]]), np.max([chans[0], chans[1]]))
+            else:
+                flagchannels_string+=', %d:%d~%d' % (spw, np.min([chans[0], chans[1]]), np.max([chans[0], chans[1]]))
+            """
+            chans = np.sort(chans)
+            fitspw_dict[str(trans_spw)] = {}
+            fitspw_dict[str(trans_spw)]['fitorder']=fitorder
+            flagchannels_string=''
+            for i in range(0,chans.size-1,2):
+               flagchannels_string += '%d~%d;' % (chans[i], chans[i+1])
+            fitspw_dict[str(trans_spw)]['chan']=flagchannels_string[:-1]
+
+    return fitspw_dict
 
 def get_spw_chanwidths(vis,spwarray):
    widtharray=np.zeros(len(spwarray))


### PR DESCRIPTION
This is to fix the variety of issues that can occur when cont.dat is missing some of the targets, typically due to mitigation during the pipeline run.

As a side effect, this also brings the updates made to use the new uvcontsub that were done originally in my fork but are also valid in jjtobin/auto_selfcal main.

I have not yet tested these updates on this branch specifically, only on the companion fix_contdotdat_matching_bug branch on my fork. I'm going to try to set such a test running this weekend and can confirm that all worked as expected once that is done, hopefully by the end of the weekend.