### PR TITLE
Fix per spw imaging and weblog reporting of per-spw quantities now that spws are tracked per-EB

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -324,7 +324,7 @@ for target in all_targets:
       vislist=selfcal_library[target][band]['vislist'].copy()
 
       selfcal_library[target][band]['spw_map'] = get_spw_map(selfcal_library, 
-              vislist, target, band, spwsarray_dict)
+              target, band, telescope)
 
       #code to work around some VLA data not having the same number of spws due to missing BlBPs
       #selects spwlist from the visibilities with the greates number of spws

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -322,6 +322,10 @@ for target in all_targets:
    for band in selfcal_library[target].keys():
       selfcal_library[target][band]['per_spw_stats']={}
       vislist=selfcal_library[target][band]['vislist'].copy()
+
+      selfcal_library[target][band]['spwvisref'], selfcal_library[target][band]['spw_map'] = get_spw_map(selfcal_library, 
+              vislist, target, band, spwsarray_dict)
+
       #code to work around some VLA data not having the same number of spws due to missing BlBPs
       #selects spwlist from the visibilities with the greates number of spws
       #PS: We now track spws on an EB by EB basis soI have removed much of the maxspwvis code.
@@ -356,13 +360,13 @@ if check_all_spws:
       for band in selfcal_library[target].keys():
          vislist=selfcal_library[target][band]['vislist'].copy()
          #potential place where diff spws for different VLA EBs could cause problems
-         spwlist=selfcal_library[target][band][vis]['spws'].split(',')
+         spwlist=selfcal_library[target][band][selfcal_library[target][band]['spwvisref']]['spws'].split(',')
          for spw in spwlist:
             keylist=selfcal_library[target][band]['per_spw_stats'].keys()
             if spw not in keylist:
                selfcal_library[target][band]['per_spw_stats'][spw]={}
             if not os.path.exists(sani_target+'_'+band+'_'+spw+'_dirty.image.tt0'):
-               spws_per_vis=[spw]*len(vislist)
+               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][int(spw)][vis]) for vis in vislist]
                tclean_wrapper(vislist,sani_target+'_'+band+'_'+spw+'_dirty',
                      band_properties,band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold='0.0Jy',niter=0,
@@ -385,7 +389,7 @@ if check_all_spws:
                      sensitivity=sensitivity*4.0 
                else:
                   sensitivity=0.0
-               spws_per_vis=[spw]*len(vislist)  #assumes all spw ids are identical in each MS file
+               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][int(spw)][vis]) for vis in vislist]
 
                tclean_wrapper(vislist,sani_target+'_'+band+'_'+spw+'_initial',\
                           band_properties,band,telescope=telescope,nsigma=4.0, threshold=str(sensitivity*4.0)+'Jy',scales=[0],\
@@ -967,7 +971,7 @@ if check_all_spws:
       for band in selfcal_library[target].keys():
          vislist=selfcal_library[target][band]['vislist'].copy()
 
-         spwlist=selfcal_library[target][band][vis]['spws'].split(',')
+         spwlist=selfcal_library[target][band][selfcal_library[target][band]['spwvisref']]['spws'].split(',')
          print('Generating final per-SPW images for '+target+' in '+band)
          for spw in spwlist:
    ## omit DR modifiers here since we should have increased DR significantly
@@ -983,7 +987,7 @@ if check_all_spws:
                      sensitivity=sensitivity*4.0 
                else:
                   sensitivity=0.0
-               spws_per_vis=[spw]*len(vislist)  #assumes all spw ids are identical in each MS file
+               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][int(spw)][vis]) for vis in vislist]
                nfsnr_modifier = selfcal_library[target][band]['RMS_NF_curr'] / selfcal_library[target][band]['RMS_curr']
                sensitivity_agg=get_sensitivity(vislist,selfcal_library[target][band],target,selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
                sensitivity_scale_factor=selfcal_library[target][band]['RMS_curr']/sensitivity_agg

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -265,7 +265,7 @@ for target in all_targets:
       dirty_NF_SNR,dirty_NF_RMS=dirty_SNR,dirty_RMS
    dr_mod=1.0
    if telescope =='ALMA' or telescope =='ACA':
-      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
+      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,virtual_spw='all',imsize=imsize[band],cellsize=cellsize[band])
       dr_mod=get_dr_correction(telescope,dirty_SNR*dirty_RMS,sensitivity,vislist)
       sensitivity_nomod=sensitivity.copy()
       print('DR modifier: ',dr_mod)
@@ -364,22 +364,22 @@ if check_all_spws:
             keylist=selfcal_library[target][band]['per_spw_stats'].keys()
             if spw not in keylist:
                selfcal_library[target][band]['per_spw_stats'][spw]={}
-            if not os.path.exists(sani_target+'_'+band+'_'+spw+'_dirty.image.tt0'):
+            if not os.path.exists(sani_target+'_'+band+'_'+str(spw)+'_dirty.image.tt0'):
                spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vislist]
-               tclean_wrapper(vislist,sani_target+'_'+band+'_'+spw+'_dirty',
+               tclean_wrapper(vislist,sani_target+'_'+band+'_'+str(spw)+'_dirty',
                      band_properties,band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold='0.0Jy',niter=0,
                      savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],nterms=1,
                      field=target,spw=spws_per_vis,
                      uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'])
-            dirty_SNR,dirty_RMS=estimate_SNR(sani_target+'_'+band+'_'+spw+'_dirty.image.tt0')
+            dirty_SNR,dirty_RMS=estimate_SNR(sani_target+'_'+band+'_'+str(spw)+'_dirty.image.tt0')
             if telescope!='ACA':
-               dirty_per_spw_NF_SNR,dirty_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+spw+'_dirty.image.tt0', las=selfcal_library[target][band]['LAS'])
+               dirty_per_spw_NF_SNR,dirty_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+str(spw)+'_dirty.image.tt0', las=selfcal_library[target][band]['LAS'])
             else:
                dirty_per_spw_NF_SNR,dirty_per_spw_NF_RMS=per_spw_SNR,per_spw_RMS
-            if not os.path.exists(sani_target+'_'+band+'_'+spw+'_initial.image.tt0'):
+            if not os.path.exists(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0'):
                if telescope=='ALMA' or telescope =='ACA':
-                  sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,spw,spw=np.array([int(spw)]),imsize=imsize[band],cellsize=cellsize[band])
+                  sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,virtual_spw=spw,imsize=imsize[band],cellsize=cellsize[band])
                   dr_mod=1.0
                   dr_mod=get_dr_correction(telescope,dirty_SNR*dirty_RMS,sensitivity,vislist)
                   print('DR modifier: ',dr_mod,'SPW: ',spw)
@@ -390,25 +390,25 @@ if check_all_spws:
                   sensitivity=0.0
                spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vislist]
 
-               tclean_wrapper(vislist,sani_target+'_'+band+'_'+spw+'_initial',\
+               tclean_wrapper(vislist,sani_target+'_'+band+'_'+str(spw)+'_initial',\
                           band_properties,band,telescope=telescope,nsigma=4.0, threshold=str(sensitivity*4.0)+'Jy',scales=[0],\
                           savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],\
                           nterms=1,field=target,datacolumn='corrected',\
                           spw=spws_per_vis,uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], \
                           nfrms_multiplier=dirty_per_spw_NF_RMS/dirty_RMS)
 
-            per_spw_SNR,per_spw_RMS=estimate_SNR(sani_target+'_'+band+'_'+spw+'_initial.image.tt0')
+            per_spw_SNR,per_spw_RMS=estimate_SNR(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0')
             if telescope!='ACA':
-               initial_per_spw_NF_SNR,initial_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+spw+'_initial.image.tt0', las=selfcal_library[target][band]['LAS'])
+               initial_per_spw_NF_SNR,initial_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0', las=selfcal_library[target][band]['LAS'])
             else:
                initial_per_spw_NF_SNR,initial_per_spw_NF_RMS=per_spw_SNR,per_spw_RMS
             selfcal_library[target][band]['per_spw_stats'][spw]['SNR_orig']=per_spw_SNR
             selfcal_library[target][band]['per_spw_stats'][spw]['RMS_orig']=per_spw_RMS
             selfcal_library[target][band]['per_spw_stats'][spw]['SNR_NF_orig']=initial_per_spw_NF_SNR
             selfcal_library[target][band]['per_spw_stats'][spw]['RMS_NF_orig']=initial_per_spw_NF_RMS
-            goodMask=checkmask(sani_target+'_'+band+'_'+spw+'_initial.image.tt0')
+            goodMask=checkmask(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0')
             if goodMask:
-               selfcal_library[target][band]['per_spw_stats'][spw]['intflux_orig'],selfcal_library[target][band]['per_spw_stats'][spw]['e_intflux_orig']=get_intflux(sani_target+'_'+band+'_'+spw+'_initial.image.tt0',per_spw_RMS)
+               selfcal_library[target][band]['per_spw_stats'][spw]['intflux_orig'],selfcal_library[target][band]['per_spw_stats'][spw]['e_intflux_orig']=get_intflux(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0',per_spw_RMS)
             else:
                selfcal_library[target][band]['per_spw_stats'][spw]['intflux_orig'],selfcal_library[target][band]['per_spw_stats'][spw]['e_intflux_orig']=-99.0,-99.0               
 
@@ -486,7 +486,7 @@ for target in all_targets:
       selfcal_library[target][band]['nsigma']=np.append(10**np.linspace(np.log10(nsigma_init),np.log10(3.0),len(solints[band])-n_ap_solints),np.array([10**(np.log10(3.0))]*n_ap_solints))
 
    if telescope=='ALMA' or telescope =='ACA': #or ('VLA' in telescope) 
-      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
+      sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,virtual_spw='all',imsize=imsize[band],cellsize=cellsize[band])
       if band =='Band_9' or band == 'Band_10':   # adjust for DSB noise increase
          sensitivity=sensitivity*4.0 
       if ('VLA' in telescope):
@@ -973,9 +973,9 @@ if check_all_spws:
          print('Generating final per-SPW images for '+target+' in '+band)
          for spw in selfcal_library[target][band]['spw_map']:
    ## omit DR modifiers here since we should have increased DR significantly
-            if not os.path.exists(sani_target+'_'+band+'_'+spw+'_final.image.tt0'):
+            if not os.path.exists(sani_target+'_'+band+'_'+str(spw)+'_final.image.tt0'):
                if telescope=='ALMA' or telescope =='ACA':
-                  sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,spw,spw=np.array([int(spw)]),imsize=imsize[band],cellsize=cellsize[band])
+                  sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,virtual_spw=spw,imsize=imsize[band],cellsize=cellsize[band])
                   dr_mod=1.0
                   if not selfcal_library[target][band]['SC_success']: # fetch the DR modifier if selfcal failed on source
                      dr_mod=get_dr_correction(telescope,selfcal_library[target][band]['SNR_dirty']*selfcal_library[target][band]['RMS_dirty'],sensitivity,vislist)
@@ -987,18 +987,18 @@ if check_all_spws:
                   sensitivity=0.0
                spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vislist]
                nfsnr_modifier = selfcal_library[target][band]['RMS_NF_curr'] / selfcal_library[target][band]['RMS_curr']
-               sensitivity_agg=get_sensitivity(vislist,selfcal_library[target][band],target,selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
+               sensitivity_agg=get_sensitivity(vislist,selfcal_library[target][band],target,virtual_spw='all',imsize=imsize[band],cellsize=cellsize[band])
                sensitivity_scale_factor=selfcal_library[target][band]['RMS_curr']/sensitivity_agg
 
-               tclean_wrapper(vislist,sani_target+'_'+band+'_'+spw+'_final',\
+               tclean_wrapper(vislist,sani_target+'_'+band+'_'+str(spw)+'_final',\
                           band_properties,band,telescope=telescope,nsigma=4.0, threshold=str(sensitivity*sensitivity_scale_factor*4.0)+'Jy',scales=[0],\
                           savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],\
                           nterms=1,field=target,datacolumn='corrected',\
                           spw=spws_per_vis,uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'],
                           nfrms_multiplier=nfsnr_modifier)
-            final_per_spw_SNR,final_per_spw_RMS=estimate_SNR(sani_target+'_'+band+'_'+spw+'_final.image.tt0')
+            final_per_spw_SNR,final_per_spw_RMS=estimate_SNR(sani_target+'_'+band+'_'+str(spw)+'_final.image.tt0')
             if telescope !='ACA':
-               final_per_spw_NF_SNR,final_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+spw+'_final.image.tt0', las=selfcal_library[target][band]['LAS'])
+               final_per_spw_NF_SNR,final_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+str(spw)+'_final.image.tt0', las=selfcal_library[target][band]['LAS'])
             else:
                final_per_spw_NF_SNR,final_per_spw_NF_RMS=final_per_spw_SNR,final_per_spw_RMS
 
@@ -1007,9 +1007,9 @@ if check_all_spws:
             selfcal_library[target][band]['per_spw_stats'][spw]['SNR_NF_final']=final_per_spw_NF_SNR
             selfcal_library[target][band]['per_spw_stats'][spw]['RMS_NF_final']=final_per_spw_NF_RMS
             #reccalc initial stats with final mask
-            final_per_spw_SNR,final_per_spw_RMS=estimate_SNR(sani_target+'_'+band+'_'+spw+'_initial.image.tt0',maskname=sani_target+'_'+band+'_'+spw+'_final.mask')
+            final_per_spw_SNR,final_per_spw_RMS=estimate_SNR(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0',maskname=sani_target+'_'+band+'_'+str(spw)+'_final.mask')
             if telescope !='ACA':
-               final_per_spw_NF_SNR,final_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+spw+'_initial.image.tt0',maskname=sani_target+'_'+band+'_'+spw+'_final.mask', las=selfcal_library[target][band]['LAS'])
+               final_per_spw_NF_SNR,final_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0',maskname=sani_target+'_'+band+'_'+str(spw)+'_final.mask', las=selfcal_library[target][band]['LAS'])
             else:
                final_per_spw_NF_SNR,final_per_spw_NF_RMS=final_per_spw_SNR,final_per_spw_RMS
             selfcal_library[target][band]['per_spw_stats'][spw]['SNR_orig']=final_per_spw_SNR
@@ -1019,9 +1019,9 @@ if check_all_spws:
 
 
 
-            goodMask=checkmask(sani_target+'_'+band+'_'+spw+'_final.image.tt0')
+            goodMask=checkmask(sani_target+'_'+band+'_'+str(spw)+'_final.image.tt0')
             if goodMask:
-               selfcal_library[target][band]['per_spw_stats'][spw]['intflux_final'],selfcal_library[target][band]['per_spw_stats'][spw]['e_intflux_final']=get_intflux(sani_target+'_'+band+'_'+spw+'_final.image.tt0',final_per_spw_RMS)
+               selfcal_library[target][band]['per_spw_stats'][spw]['intflux_final'],selfcal_library[target][band]['per_spw_stats'][spw]['e_intflux_final']=get_intflux(sani_target+'_'+band+'_'+str(spw)+'_final.image.tt0',final_per_spw_RMS)
             else:
                selfcal_library[target][band]['per_spw_stats'][spw]['intflux_final'],selfcal_library[target][band]['per_spw_stats'][spw]['e_intflux_final']=-99.0,-99.0               
 
@@ -1105,10 +1105,9 @@ if check_all_spws:
       for band in selfcal_library[target].keys():
          vislist=selfcal_library[target][band]['vislist'].copy()
 
-         spwlist=selfcal_library[target][band][vis]['spws'].split(',')
-         for spw in spwlist:
-            delta_beamarea=compare_beams(sani_target+'_'+band+'_'+spw+'_initial.image.tt0',\
-                                         sani_target+'_'+band+'_'+spw+'_final.image.tt0')
+         for spw in selfcal_library[target][band]['spw_map']:
+            delta_beamarea=compare_beams(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0',\
+                                         sani_target+'_'+band+'_'+str(spw)+'_final.image.tt0')
             delta_SNR=selfcal_library[target][band]['per_spw_stats'][spw]['SNR_final']-\
                       selfcal_library[target][band]['per_spw_stats'][spw]['SNR_orig']
             delta_RMS=selfcal_library[target][band]['per_spw_stats'][spw]['RMS_final']-\
@@ -1116,15 +1115,15 @@ if check_all_spws:
             selfcal_library[target][band]['per_spw_stats'][spw]['delta_SNR']=delta_SNR
             selfcal_library[target][band]['per_spw_stats'][spw]['delta_RMS']=delta_RMS
             selfcal_library[target][band]['per_spw_stats'][spw]['delta_beamarea']=delta_beamarea
-            print(sani_target+'_'+band+'_'+spw,\
+            print(sani_target+'_'+band+'_'+str(spw),\
                   'Pre SNR: {:0.2f}, Post SNR: {:0.2f} Pre RMS: {:0.3f}, Post RMS: {:0.3f}'.format(selfcal_library[target][band]['per_spw_stats'][spw]['SNR_orig'],\
                    selfcal_library[target][band]['per_spw_stats'][spw]['SNR_final'],selfcal_library[target][band]['per_spw_stats'][spw]['RMS_orig']*1000.0,selfcal_library[target][band]['per_spw_stats'][spw]['RMS_final']*1000.0))
             if delta_SNR < 0.0:
-               print('WARNING SPW '+spw+' HAS LOWER SNR POST SELFCAL')
+               print('WARNING SPW '+str(spw)+' HAS LOWER SNR POST SELFCAL')
             if delta_RMS > 0.0:
-               print('WARNING SPW '+spw+' HAS HIGHER RMS POST SELFCAL')
+               print('WARNING SPW '+str(spw)+' HAS HIGHER RMS POST SELFCAL')
             if delta_beamarea > 0.05:
-               print('WARNING SPW '+spw+' HAS A >0.05 CHANGE IN BEAM AREA POST SELFCAL')
+               print('WARNING SPW '+str(spw)+' HAS A >0.05 CHANGE IN BEAM AREA POST SELFCAL')
 
 
 ##

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -62,14 +62,12 @@ apply_cal_mode_default='calflag'
 rel_thresh_scaling='log10'  #can set to linear, log10, or loge (natural log)
 dividing_factor=-99.0  # number that the peak SNR is divided by to determine first clean threshold -99.0 uses default
                        # default is 40 for <8ghz and 15.0 for all other frequencies
-check_all_spws=True   # generate per-spw images to check phase transfer did not go poorly for narrow windows
+check_all_spws=False   # generate per-spw images to check phase transfer did not go poorly for narrow windows
 apply_to_target_ms=False # apply final selfcal solutions back to the input _target.ms files
 
-"""
 if 'VLA' in telescope:
    check_all_spws=False
    #inf_EB_gaincal_combine='spw,scan'
-"""
 ##
 ## Import inital MS files to get relevant meta data
 ##

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -376,7 +376,7 @@ if check_all_spws:
             if telescope!='ACA':
                dirty_per_spw_NF_SNR,dirty_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+str(spw)+'_dirty.image.tt0', las=selfcal_library[target][band]['LAS'])
             else:
-               dirty_per_spw_NF_SNR,dirty_per_spw_NF_RMS=per_spw_SNR,per_spw_RMS
+               dirty_per_spw_NF_SNR,dirty_per_spw_NF_RMS=dirty_SNR,dirty_RMS
             if not os.path.exists(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0'):
                if telescope=='ALMA' or telescope =='ACA':
                   sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,virtual_spw=spw,imsize=imsize[band],cellsize=cellsize[band])

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -976,23 +976,24 @@ if check_all_spws:
          for spw in selfcal_library[target][band]['spw_map']:
    ## omit DR modifiers here since we should have increased DR significantly
             if not os.path.exists(sani_target+'_'+band+'_'+str(spw)+'_final.image.tt0'):
+               vlist = [vis for vis in vislist if vis in selfcal_library[target][band]['spw_map'][spw]]
                if telescope=='ALMA' or telescope =='ACA':
-                  sensitivity=get_sensitivity(vislist,selfcal_library[target][band],target,virtual_spw=spw,imsize=imsize[band],cellsize=cellsize[band])
+                  sensitivity=get_sensitivity(vlist,selfcal_library[target][band],target,virtual_spw=spw,imsize=imsize[band],cellsize=cellsize[band])
                   dr_mod=1.0
                   if not selfcal_library[target][band]['SC_success']: # fetch the DR modifier if selfcal failed on source
-                     dr_mod=get_dr_correction(telescope,selfcal_library[target][band]['SNR_dirty']*selfcal_library[target][band]['RMS_dirty'],sensitivity,vislist)
+                     dr_mod=get_dr_correction(telescope,selfcal_library[target][band]['SNR_dirty']*selfcal_library[target][band]['RMS_dirty'],sensitivity,vlist)
                   print('DR modifier: ',dr_mod, 'SPW: ',spw)
                   sensitivity=sensitivity*dr_mod 
                   if ((band =='Band_9') or (band == 'Band_10')) and dr_mod != 1.0:   # adjust for DSB noise increase
                      sensitivity=sensitivity*4.0 
                else:
                   sensitivity=0.0
-               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vislist]
+               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vlist]
                nfsnr_modifier = selfcal_library[target][band]['RMS_NF_curr'] / selfcal_library[target][band]['RMS_curr']
-               sensitivity_agg=get_sensitivity(vislist,selfcal_library[target][band],target,virtual_spw='all',imsize=imsize[band],cellsize=cellsize[band])
+               sensitivity_agg=get_sensitivity(vlist,selfcal_library[target][band],target,virtual_spw='all',imsize=imsize[band],cellsize=cellsize[band])
                sensitivity_scale_factor=selfcal_library[target][band]['RMS_curr']/sensitivity_agg
 
-               tclean_wrapper(vislist,sani_target+'_'+band+'_'+str(spw)+'_final',\
+               tclean_wrapper(vlist,sani_target+'_'+band+'_'+str(spw)+'_final',\
                           band_properties,band,telescope=telescope,nsigma=4.0, threshold=str(sensitivity*sensitivity_scale_factor*4.0)+'Jy',scales=[0],\
                           savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],\
                           nterms=1,field=target,datacolumn='corrected',\

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -365,8 +365,9 @@ if check_all_spws:
             if spw not in keylist:
                selfcal_library[target][band]['per_spw_stats'][spw]={}
             if not os.path.exists(sani_target+'_'+band+'_'+str(spw)+'_dirty.image.tt0'):
-               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vislist]
-               tclean_wrapper(vislist,sani_target+'_'+band+'_'+str(spw)+'_dirty',
+               vlist = [vis if vis in selfcal_library[target][band]['spw_map'][spw] for vis in vislist]
+               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vlist]
+               tclean_wrapper(vlist,sani_target+'_'+band+'_'+str(spw)+'_dirty',
                      band_properties,band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold='0.0Jy',niter=0,
                      savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],nterms=1,

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -323,7 +323,7 @@ for target in all_targets:
       selfcal_library[target][band]['per_spw_stats']={}
       vislist=selfcal_library[target][band]['vislist'].copy()
 
-      selfcal_library[target][band]['spwvisref'], selfcal_library[target][band]['spw_map'] = get_spw_map(selfcal_library, 
+      selfcal_library[target][band]['spw_map'] = get_spw_map(selfcal_library, 
               vislist, target, band, spwsarray_dict)
 
       #code to work around some VLA data not having the same number of spws due to missing BlBPs
@@ -360,13 +360,12 @@ if check_all_spws:
       for band in selfcal_library[target].keys():
          vislist=selfcal_library[target][band]['vislist'].copy()
          #potential place where diff spws for different VLA EBs could cause problems
-         spwlist=selfcal_library[target][band][selfcal_library[target][band]['spwvisref']]['spws'].split(',')
-         for spw in spwlist:
+         for spw in selfcal_library[target][band]['spw_map']:
             keylist=selfcal_library[target][band]['per_spw_stats'].keys()
             if spw not in keylist:
                selfcal_library[target][band]['per_spw_stats'][spw]={}
             if not os.path.exists(sani_target+'_'+band+'_'+spw+'_dirty.image.tt0'):
-               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][int(spw)][vis]) for vis in vislist]
+               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vislist]
                tclean_wrapper(vislist,sani_target+'_'+band+'_'+spw+'_dirty',
                      band_properties,band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold='0.0Jy',niter=0,
@@ -389,7 +388,7 @@ if check_all_spws:
                      sensitivity=sensitivity*4.0 
                else:
                   sensitivity=0.0
-               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][int(spw)][vis]) for vis in vislist]
+               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vislist]
 
                tclean_wrapper(vislist,sani_target+'_'+band+'_'+spw+'_initial',\
                           band_properties,band,telescope=telescope,nsigma=4.0, threshold=str(sensitivity*4.0)+'Jy',scales=[0],\
@@ -971,9 +970,8 @@ if check_all_spws:
       for band in selfcal_library[target].keys():
          vislist=selfcal_library[target][band]['vislist'].copy()
 
-         spwlist=selfcal_library[target][band][selfcal_library[target][band]['spwvisref']]['spws'].split(',')
          print('Generating final per-SPW images for '+target+' in '+band)
-         for spw in spwlist:
+         for spw in selfcal_library[target][band]['spw_map']:
    ## omit DR modifiers here since we should have increased DR significantly
             if not os.path.exists(sani_target+'_'+band+'_'+spw+'_final.image.tt0'):
                if telescope=='ALMA' or telescope =='ACA':
@@ -987,7 +985,7 @@ if check_all_spws:
                      sensitivity=sensitivity*4.0 
                else:
                   sensitivity=0.0
-               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][int(spw)][vis]) for vis in vislist]
+               spws_per_vis=[str(selfcal_library[target][band]['spw_map'][spw][vis]) for vis in vislist]
                nfsnr_modifier = selfcal_library[target][band]['RMS_NF_curr'] / selfcal_library[target][band]['RMS_curr']
                sensitivity_agg=get_sensitivity(vislist,selfcal_library[target][band],target,selfcal_library[target][band][vis]['spws'],spw=selfcal_library[target][band][vis]['spwsarray'],imsize=imsize[band],cellsize=cellsize[band])
                sensitivity_scale_factor=selfcal_library[target][band]['RMS_curr']/sensitivity_agg

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -201,7 +201,7 @@ def fetch_scan_times(vislist,targets):
          for scan in scansdict[vis][target]:
             spws_set_dict[vis][scan]=np.array([])
             spws=msmd.spwsforscan(scan)
-            print(scan, spws)
+            #print(scan, spws)
             spws_set_dict[vis][scan]=spws.copy()
             n_spws=np.append(len(spws),n_spws)
             min_spws=np.append(np.min(spws),min_spws)
@@ -247,6 +247,7 @@ def fetch_scan_times_band_aware(vislist,targets,band_properties,band):
    integrationtimes=np.array([])
    n_spws=np.array([])
    min_spws=np.array([])
+   scansforspw=np.array([])
    spwslist=np.array([])
    spws_set_dict = {}
    mosaic_field={}
@@ -262,7 +263,10 @@ def fetch_scan_times_band_aware(vislist,targets,band_properties,band):
       msmd.open(vis)
       for target in targets:
          scansforfield=msmd.scansforfield(target)
-         scansforspw=msmd.scansforspw(band_properties[vis][band]['spwarray'][0])
+         for spw in band_properties[vis][band]['spwarray']:
+            scansforspw_temp=msmd.scansforspw(spw)
+            scansforspw=np.append(scansforspw,np.array(scansforspw_temp,dtype=int))
+         scansforspw=scansforspw.astype(int)
          scansdict[vis][target]=list(set(scansforfield) & set(scansforspw))
          scansdict[vis][target].sort()
       for target in targets:
@@ -929,7 +933,7 @@ def LSRKfreq_to_chan(msfile, field, spw, LSRKfreq,spwsarray,minmaxchans=False):
     matching_index=np.where(spw==spwsarray)
     alt_spw=uniquespws[matching_index[0][0]]
     alt_spw=int(alt_spw) # work around spw begin an np.uint64
-    print(spw,alt_spw,matching_index[0])
+    #print(spw,alt_spw,matching_index[0])
     tb.close()
     obsid = np.unique(obs_col[np.where(spw_col==alt_spw)]) 
     
@@ -948,8 +952,8 @@ def LSRKfreq_to_chan(msfile, field, spw, LSRKfreq,spwsarray,minmaxchans=False):
     lsrkfreqs = ms.cvelfreqs(spwids = [spw], fieldids = int(np.where(fieldnames==field)[0][0]), mode = 'channel', nchan = nchan, \
             obstime = str(obstime)+'s', start = 0, outframe = 'LSRK') / 1e9
     ms.close()
-    print(spw,alt_spw,field,int(np.where(fieldnames==field)[0][0]))
-    print(lsrkfreqs)
+    #print(spw,alt_spw,field,int(np.where(fieldnames==field)[0][0]))
+    #print(lsrkfreqs)
 
     if type(LSRKfreq)==np.ndarray:
         if minmaxchans:
@@ -963,7 +967,7 @@ def LSRKfreq_to_chan(msfile, field, spw, LSRKfreq,spwsarray,minmaxchans=False):
             outchans = np.zeros_like(LSRKfreq)
             for i in range(len(LSRKfreq)):
                 outchans[i] = np.argmin(np.abs(lsrkfreqs - LSRKfreq[i]))
-            print(outchans)
+            #print(outchans)
         return outchans
     else:
         if minmaxchans:

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2138,11 +2138,13 @@ def render_spw_stats_summary_table(htmlOut,sclib,target,band):
                 line+='    <td>{:0.3f}</td>\n'.format(sclib[target][band]['per_spw_stats'][spw][key])
              if 'RMS' in key and key in spwkeys:
                 line+='    <td>{:0.3e} mJy/bm</td>\n'.format(sclib[target][band]['per_spw_stats'][spw][key]*1000.0)
-         vis = sclib[target][band]['vislist'][0]
+         vis = list(sclib[target][band]['spw_map'][spw].keys())[0]
          if 'bandwidth' in key and key in sclib[target][band][vis]['per_spw_stats'][sclib[target][band]['spw_map'][spw][vis]].keys():
             line+='    <td>{:0.4f} GHz</td>\n'.format(sclib[target][band][vis]['per_spw_stats'][sclib[target][band]['spw_map'][spw][vis]][key])
-         if key in sclib[target][band]['vislist']:
+         if key in sclib[target][band]['vislist'] and key in sclib[target][band]['spw_map'][spw]:
             line+='    <td>{:0d}</td>\n'.format(sclib[target][band]['spw_map'][spw][key])
+         elif key in sclib[target][band]['vislist'] and key not in sclib[target][band]['spw_map'][spw]:
+            line+='    <td>-</td>\n'
       line+='</tr>\n    '
       htmlOut.writelines(line)
    htmlOut.writelines('</table>\n')

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1146,7 +1146,18 @@ def get_fitspw_dict(vis,target,spwsarray,vislist,spwvisref,contdotdat,fitorder=1
         spws=msmd.spwsfornames(spwname)
         msmd.close()
         # must directly cast to int, otherwise the CASA tool call does not like numpy.uint64
-        trans_spw=int(np.max(spws[spwname])) # assume higher number spw is the correct one, generally true with ALMA data structure
+        #loop through returned spws to see which is in the spw array rather than assuming, because assumptions be damned
+        for check_spw in spws[spwname]:
+           matching_index=np.where(check_spw == spwsarray)
+           if len(matching_index[0]) == 0:
+              continue
+           else:
+              trans_spw=check_spw
+              break
+        if trans_spw==0:
+           print('COULD NOT DETERMINE SPW MAPPING FOR CONT.DAT, PROCEEDING WITHOUT FLAGGING FOR '+vis)
+           return ''
+        #trans_spw=int(np.max(spws[spwname])) # assume higher number spw is the correct one, generally true with ALMA data structure
         #flagchannels_string += '%d:' % (trans_spw)
         tb.open(vis+'/SPECTRAL_WINDOW')
         nchan = tb.getcol('CHAN_FREQ', startrow = trans_spw, nrow = 1).size

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2201,15 +2201,20 @@ def render_spw_stats_summary_table(htmlOut,sclib,target,band):
    htmlOut.writelines('<table cellspacing="0" cellpadding="0" border="0" bgcolor="#000000">\n')
    htmlOut.writelines('	<tr>\n')
    htmlOut.writelines('		<td>\n')
-   line='<table>\n  <tr bgcolor="#ffffff">\n    <th></th>\n    '
+   line='<table>\n  <tr bgcolor="#ffffff">\n    <th>Virtual SPW ID:</th>\n    '
    for spw in spwlist:
       line+='<th>'+str(spw)+'</th>\n    '
    line+='</tr>\n'
+   line+='<tr bgcolor="#ffffff">\n    <td colspan="{0:d}" style="text-align: center">Virtual SPW to real SPW mapping</td>\n</tr>\n'.format(len(spwlist)+1)
    htmlOut.writelines(line)
 
    quantities=sclib[target][band]['vislist'] + ['bandwidth','effective_bandwidth','SNR_orig','SNR_final','RMS_orig','RMS_final']
    for key in quantities:
-      line='<tr bgcolor="#ffffff">\n    <td>'+key+': </td>\n'
+      if key == 'bandwidth':
+         line = '<tr bgcolor="#ffffff">\n    <td colspan="{0:d}" style="text-align: center">Metadata and Statistics</td>\n</tr>\n'.format(len(spwlist)+1)
+      else:
+         line = ''
+      line+='<tr bgcolor="#ffffff">\n    <td>'+key+': </td>\n'
       for spw in spwlist:
          if spw in sclib[target][band]['per_spw_stats']:
              spwkeys=sclib[target][band]['per_spw_stats'][spw].keys()

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2086,7 +2086,7 @@ def render_selfcal_solint_summary_table(htmlOut,sclib,target,band,solints):
          htmlOut.writelines('</table>\n')
 
 def render_spw_stats_summary_table(htmlOut,sclib,target,band):
-   spwlist=list(sclib[target][band]['per_spw_stats'].keys())
+   spwlist=list(sclib[target][band]['spw_map'].keys())
    htmlOut.writelines('<br>Per SPW stats: <br>\n')
    htmlOut.writelines('<table cellspacing="0" cellpadding="0" border="0" bgcolor="#000000">\n')
    htmlOut.writelines('	<tr>\n')

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2107,8 +2107,8 @@ def render_spw_stats_summary_table(htmlOut,sclib,target,band):
                 line+='    <td>{:0.3f}</td>\n'.format(sclib[target][band]['per_spw_stats'][spw][key])
              if 'RMS' in key and key in spwkeys:
                 line+='    <td>{:0.3e} mJy/bm</td>\n'.format(sclib[target][band]['per_spw_stats'][spw][key]*1000.0)
-         if 'bandwidth' in key and key in sclib[target][band][sclib[target][band]['vislist'][0]]['per_spw_stats'][spw].keys():
-            vis = sclib[target][band]['vislist'][0]
+         vis = sclib[target][band]['vislist'][0]
+         if 'bandwidth' in key and key in sclib[target][band][vis]['per_spw_stats'][sclib[target][band]['spw_map'][spw][vis]].keys():
             line+='    <td>{:0.4f} GHz</td>\n'.format(sclib[target][band][vis]['per_spw_stats'][sclib[target][band]['spw_map'][spw][vis]][key])
          if key in sclib[target][band]['vislist']:
             line+='    <td>{:0d}</td>\n'.format(sclib[target][band]['spw_map'][spw][key])

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1147,6 +1147,7 @@ def get_fitspw_dict(vis,target,spwsarray,vislist,spwvisref,contdotdat,fitorder=1
         msmd.close()
         # must directly cast to int, otherwise the CASA tool call does not like numpy.uint64
         #loop through returned spws to see which is in the spw array rather than assuming, because assumptions be damned
+        trans_spw = -1
         for check_spw in spws[spwname]:
            matching_index=np.where(check_spw == spwsarray)
            if len(matching_index[0]) == 0:
@@ -1154,7 +1155,7 @@ def get_fitspw_dict(vis,target,spwsarray,vislist,spwvisref,contdotdat,fitorder=1
            else:
               trans_spw=check_spw
               break
-        if trans_spw==0:
+        if trans_spw==-1:
            print('COULD NOT DETERMINE SPW MAPPING FOR CONT.DAT, PROCEEDING WITHOUT FLAGGING FOR '+vis)
            return ''
         #trans_spw=int(np.max(spws[spwname])) # assume higher number spw is the correct one, generally true with ALMA data structure
@@ -1227,7 +1228,7 @@ def get_spw_eff_bandwidth(vis,target,vislist,spwsarray_dict):
       msmd.open(vis)
       spws=msmd.spwsfornames(spwname)
       msmd.close()
-      trans_spw=0
+      trans_spw=-1
       # must directly cast to int, otherwise the CASA tool call does not like numpy.uint64
       #loop through returned spws to see which is in the spw array rather than assuming, because assumptions be damned
       for check_spw in spws[spwname]:


### PR DESCRIPTION
When we made the change to track spw properties on a per-EB basis, this led to the per-SPW stats table in the weblog to no longer be rendered properly, as the information it was requesting was now under a vis layer. In fixing this, I also realized that per-spw imaging would no longer work, or really was never working correctly for cases where spws differed between EBs. This PR is to fix both issues, so now the weblog will render correctly and per-spw images will be done with the correct sets of spws.

As a note, as the PR currently stands, the code now creates a "spw_map" that maps the real spws in each EB to a virtual spw id that is 0-based. I.e. the virtual spw numbers have nothing to do with the original spw IDs. I did this because it was much simpler to do it this way. Nominally if there's a 1-to-1 mapping between the spws in all EBs, it is ok to just use a reference EB to set the virtual spws. But when there isn't that 1-to-1 mapping, it gets a little harder to determine how to do this properly, so I thought it was most straightforward to just start with 0 and count up.

That said, we did discuss that this could be confusing, so it may be worth reviewing a weblog to see if there's any additional information we could put in before we merge this.

Another note: I have tested that this works with check_all_spws=True and check_all_spws=False for ALMA data. We have hard-coded that check_all_spws=False for VLA data, and it works in that case. For good measure I'm overriding that check_all_spws=False to force it to make the per-spw images. That may take a while to run through, and given that the release will have that hard-coded False, we may not need to wait on that to actually merge.