### PR TITLE
Fix issues where the stats recorded and/or the the outcome of selfcal depends on the order in which EBs or bands are done

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -469,10 +469,10 @@ for target in all_targets:
 for target in all_targets:
   for band in selfcal_library[target].keys():
    if band_properties[selfcal_library[target][band]['vislist'][0]][band]['meanfreq'] <8.0e9 and (dividing_factor ==-99.0):
-      dividing_factor=40.0
+      dividing_factor_band=40.0
    elif (dividing_factor ==-99.0):
-      dividing_factor=15.0
-   nsigma_init=np.max([selfcal_library[target][band]['SNR_orig']/dividing_factor,5.0]) # restricts initial nsigma to be at least 5
+      dividing_factor_band=15.0
+   nsigma_init=np.max([selfcal_library[target][band]['SNR_orig']/dividing_factor_band,5.0]) # restricts initial nsigma to be at least 5
    
    n_ap_solints=sum(1 for solint in solints[band] if 'ap' in solint)  # count number of amplitude selfcal solints, repeat final clean depth of phase-only for amplitude selfcal
    if rel_thresh_scaling == 'loge':

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -783,6 +783,7 @@ for target in all_targets:
             ##
             ## record self cal results/details for this solint
             ##
+            header=imhead(imagename=sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0')
             selfcal_library[target][band][vis][solint]={}
             selfcal_library[target][band][vis][solint]['SNR_pre']=SNR.copy()
             selfcal_library[target][band][vis][solint]['RMS_pre']=RMS.copy()
@@ -796,7 +797,7 @@ for target in all_targets:
             selfcal_library[target][band][vis][solint]['spwmap']=applycal_spwmap[vis]
             selfcal_library[target][band][vis][solint]['applycal_mode']=applycal_mode[band][iteration]+''
             selfcal_library[target][band][vis][solint]['applycal_interpolate']=applycal_interpolate[vis]
-            selfcal_library[target][band][vis][solint]['gaincal_combine']=gaincal_combine[band][iteration]+''
+            selfcal_library[target][band][vis][solint]['gaincal_combine']=inf_EB_gaincal_combine_dict[target][band][vis]+'' if solint == 'inf_EB' else gaincal_combine[band][iteration]+''
             selfcal_library[target][band][vis][solint]['clean_threshold']=selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_curr']
             selfcal_library[target][band][vis][solint]['intflux_pre'],selfcal_library[target][band][vis][solint]['e_intflux_pre']=get_intflux(sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'.image.tt0',RMS)
             selfcal_library[target][band][vis][solint]['fallback']=fallback[vis]+''

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -807,9 +807,9 @@ for target in all_targets:
             selfcal_library[target][band][vis][solint]['SNR_NF_post']=post_SNR_NF.copy()
             selfcal_library[target][band][vis][solint]['RMS_NF_post']=post_RMS_NF.copy()
             ## Update RMS value if necessary
-            if selfcal_library[target][band][vis][solint]['RMS_post'] < selfcal_library[target][band]['RMS_curr']:
+            if selfcal_library[target][band][vis][solint]['RMS_post'] < selfcal_library[target][band]['RMS_curr'] and vis == vislist[-1]:
                selfcal_library[target][band]['RMS_curr']=selfcal_library[target][band][vis][solint]['RMS_post'].copy()
-            if selfcal_library[target][band][vis][solint]['RMS_NF_post'] < selfcal_library[target][band]['RMS_NF_curr']:
+            if selfcal_library[target][band][vis][solint]['RMS_NF_post'] < selfcal_library[target][band]['RMS_NF_curr'] and vis == vislist[-1]:
                selfcal_library[target][band]['RMS_NF_curr']=selfcal_library[target][band][vis][solint]['RMS_NF_post'].copy()
             header=imhead(imagename=sani_target+'_'+band+'_'+solint+'_'+str(iteration)+'_post.image.tt0')
             selfcal_library[target][band][vis][solint]['Beam_major_post']=header['restoringbeam']['major']['value']


### PR DESCRIPTION
In reviewing our regression tests for auto_selfcal, I uncovered two places where either the outcome or the stats recorded in the selfcal_library could depend on the order in which bands or EBs are analyzed:

- The `dividing_factor` parameter is initially -99 (assuming the default value) and then gets set to some value based on the first band it checks, after which it stays the same because of the condition that `dividing_factor == -99` for setting it otherwise. This can then have an impact on the clean_thresholds set (quite dramatically) which can ultimately affect how selfcal proceeds, but only if considering a multi-band observation where the bands span the 8 GHz threshold for using different `dividing_factors`.
- The stats recorded in the selfcal_library for each selfcal solint are somewhat order dependent because the pre-selfcal `header` is opened in a separate loop over `vislist` from the loop over `vislist where the `header` is used to record stats, and also because the `gaincal_combine` value was not stored per-EB, could vary from EB to EB for inf_EB, and was stored for the last EB considered. I don't believe this had an effect on selfcal downstream, I think it just led to differences in what was recorded in the selfcal_library.

This PR fixes these two issues so that the results of selfcal should no longer depend on them.