### PR TITLE
Fix sub-field RMS values for ACA post images when not using near-field masks

### DIFF
--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -760,7 +760,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                                 maskname=imagename+'.mask', las=selfcal_library[target][band]['LAS'], \
                                 mosaic_sub_field=selfcal_library[target][band]["obstype"]=="mosaic")
                  else:
-                    post_mosaic_SNR_NF[fid],post_mosaic_RMS_NF[fid]=mosaic_SNR[fid],mosaic_RMS[fid]
+                    post_mosaic_SNR_NF[fid],post_mosaic_RMS_NF[fid]=post_mosaic_SNR[fid],post_mosaic_RMS[fid]
                  print()
 
              # change nterms to 2 if needed based on fracbw and SNR


### PR DESCRIPTION
I just uncovered that for ACA post images when not allowing using the near-field mask to calculate SNR/RMS defaults back to the pre image values rather than the post image values, like what is done for the non-sub-field image. This PR fixes that so that in this case it uses  the post_mosaic_SNR and post_mosaic_RMS values instead.