### PR TITLE
Properly store final RMS/SNR

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -932,15 +932,15 @@ if check_all_spws:
             selfcal_library[target][band]['per_spw_stats'][spw]['SNR_NF_final']=final_per_spw_NF_SNR
             selfcal_library[target][band]['per_spw_stats'][spw]['RMS_NF_final']=final_per_spw_NF_RMS
             #reccalc initial stats with final mask
-            final_per_spw_SNR,final_per_spw_RMS=estimate_SNR(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0',maskname=sani_target+'_'+band+'_'+str(spw)+'_final.mask')
+            orig_final_per_spw_SNR,orig_final_per_spw_RMS=estimate_SNR(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0',maskname=sani_target+'_'+band+'_'+str(spw)+'_final.mask')
             if telescope !='ACA' or aca_use_nfmask:
-               final_per_spw_NF_SNR,final_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0',maskname=sani_target+'_'+band+'_'+str(spw)+'_final.mask', las=selfcal_library[target][band]['LAS'])
+               orig_final_per_spw_NF_SNR,orig_final_per_spw_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_'+str(spw)+'_initial.image.tt0',maskname=sani_target+'_'+band+'_'+str(spw)+'_final.mask', las=selfcal_library[target][band]['LAS'])
             else:
-               final_per_spw_NF_SNR,final_per_spw_NF_RMS=final_per_spw_SNR,final_per_spw_RMS
-            selfcal_library[target][band]['per_spw_stats'][spw]['SNR_orig']=final_per_spw_SNR
-            selfcal_library[target][band]['per_spw_stats'][spw]['RMS_orig']=final_per_spw_RMS
-            selfcal_library[target][band]['per_spw_stats'][spw]['SNR_NF_orig']=final_per_spw_NF_SNR
-            selfcal_library[target][band]['per_spw_stats'][spw]['RMS_NF_orig']=final_per_spw_NF_RMS
+               orig_final_per_spw_NF_SNR,orig_final_per_spw_NF_RMS=orig_final_per_spw_SNR,orig_final_per_spw_RMS
+            selfcal_library[target][band]['per_spw_stats'][spw]['SNR_orig']=orig_final_per_spw_SNR
+            selfcal_library[target][band]['per_spw_stats'][spw]['RMS_orig']=orig_final_per_spw_RMS
+            selfcal_library[target][band]['per_spw_stats'][spw]['SNR_NF_orig']=orig_final_per_spw_NF_SNR
+            selfcal_library[target][band]['per_spw_stats'][spw]['RMS_NF_orig']=orig_final_per_spw_NF_RMS
 
 
 

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -820,15 +820,15 @@ for target in all_targets:
    selfcal_library[target][band]['Beam_minor_final']=header['restoringbeam']['minor']['value']
    selfcal_library[target][band]['Beam_PA_final']=header['restoringbeam']['positionangle']['value'] 
    #recalc inital stats using final mask
-   final_SNR,final_RMS=estimate_SNR(sani_target+'_'+band+'_initial.image.tt0',maskname=sani_target+'_'+band+'_final.mask')
+   orig_final_SNR,orig_final_RMS=estimate_SNR(sani_target+'_'+band+'_initial.image.tt0',maskname=sani_target+'_'+band+'_final.mask')
    if telescope!='ACA' or aca_use_nfmask:
-      final_NF_SNR,final_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_initial.image.tt0',maskname=sani_target+'_'+band+'_final.mask', las=selfcal_library[target][band]['LAS'])
+      orig_final_NF_SNR,orig_final_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_initial.image.tt0',maskname=sani_target+'_'+band+'_final.mask', las=selfcal_library[target][band]['LAS'])
    else:
       final_NF_SNR,final_NF_RMS=final_SNR,final_RMS
-   selfcal_library[target][band]['SNR_orig']=final_SNR
-   selfcal_library[target][band]['RMS_orig']=final_RMS
-   selfcal_library[target][band]['SNR_NF_orig']=final_NF_SNR
-   selfcal_library[target][band]['RMS_NF_orig']=final_NF_RMS
+   selfcal_library[target][band]['SNR_orig']=orig_final_SNR
+   selfcal_library[target][band]['RMS_orig']=orig_final_RMS
+   selfcal_library[target][band]['SNR_NF_orig']=orig_final_NF_SNR
+   selfcal_library[target][band]['RMS_NF_orig']=orig_final_NF_RMS
    goodMask=checkmask(imagename=sani_target+'_'+band+'_final.image.tt0')
    if goodMask:
       selfcal_library[target][band]['intflux_final'],selfcal_library[target][band]['e_intflux_final']=get_intflux(sani_target+'_'+band+'_final.image.tt0',final_RMS)

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -824,7 +824,7 @@ for target in all_targets:
    if telescope!='ACA' or aca_use_nfmask:
       orig_final_NF_SNR,orig_final_NF_RMS=estimate_near_field_SNR(sani_target+'_'+band+'_initial.image.tt0',maskname=sani_target+'_'+band+'_final.mask', las=selfcal_library[target][band]['LAS'])
    else:
-      final_NF_SNR,final_NF_RMS=final_SNR,final_RMS
+      orig_final_NF_SNR,orig_final_NF_RMS=orig_final_SNR,orig_final_RMS
    selfcal_library[target][band]['SNR_orig']=orig_final_SNR
    selfcal_library[target][band]['RMS_orig']=orig_final_RMS
    selfcal_library[target][band]['SNR_NF_orig']=orig_final_NF_SNR


### PR DESCRIPTION
It appears that the final RMS and SNR values being stored in the selfcal_library are overwritten by the re-calculation of the original RMS/SNR values and therefore not being stored correctly. This PR fixes that.