### PR TITLE
Fix the reporting of flagging fraction for single polarization datasets

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -292,6 +292,14 @@ for target in all_targets:
       selfcal_library[target][band][vis]['spwlist']=band_properties[vis][band]['spwarray'].tolist()
       selfcal_library[target][band][vis]['n_spws']=len(selfcal_library[target][band][vis]['spwsarray'])
       selfcal_library[target][band][vis]['minspw']=int(np.min(selfcal_library[target][band][vis]['spwsarray']))
+
+      if band_properties[vis][band]['ncorrs'] == 1:
+          selfcal_library[target][band][vis]['pol_type'] = 'single-pol'
+      elif band_properties[vis][band]['ncorrs'] == 2:
+          selfcal_library[target][band][vis]['pol_type'] = 'dual-pol'
+      else:
+          selfcal_library[target][band][vis]['pol_type'] = 'full-pol'
+
       if spectral_scan:
          spwmap=np.zeros(np.max(spws_set[band][vis])+1,dtype='int')
          spwmap.fill(np.min(spws_set[band][vis]))
@@ -339,6 +347,14 @@ for target in all_targets:
           selfcal_library[target][band][fid][vis]['spwlist']=band_properties[vis][band]['spwarray'].tolist()
           selfcal_library[target][band][fid][vis]['n_spws']=len(selfcal_library[target][band][fid][vis]['spwsarray'])
           selfcal_library[target][band][fid][vis]['minspw']=int(np.min(selfcal_library[target][band][fid][vis]['spwsarray']))
+
+          if band_properties[vis][band]['ncorrs'] == 1:
+              selfcal_library[target][band][fid][vis]['pol_type'] = 'single-pol'
+          elif band_properties[vis][band]['ncorrs'] == 2:
+              selfcal_library[target][band][fid][vis]['pol_type'] = 'dual-pol'
+          else:
+              selfcal_library[target][band][fid][vis]['pol_type'] = 'full-pol'
+
           if spectral_scan:
              spwmap=np.zeros(np.max(spws_set[band][vis])+1,dtype='int')
              spwmap.fill(np.min(spws_set[band][vis]))
@@ -668,7 +684,10 @@ for target in all_targets:
     inf_EB_gaincal_combine_dict[target][band][vis]=inf_EB_gaincal_combine #'scan'
     if selfcal_library[target][band]['obstype']=='mosaic':
        inf_EB_gaincal_combine_dict[target][band][vis]+=',field'   
-    inf_EB_gaintype_dict[target][band][vis]=inf_EB_gaintype #G
+    if selfcal_library[target][band][vis]['pol_type'] == 'single-pol':
+        inf_EB_gaintype_dict[target][band][vis]='T'
+    else:
+        inf_EB_gaintype_dict[target][band][vis]=inf_EB_gaintype #G
     inf_EB_fallback_mode_dict[target][band][vis]='' #'scan'
     print('Estimated SNR per solint:')
     print(target,band)

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1662,6 +1662,10 @@ def get_ALMA_bands(vislist,spwstring,spwarray):
          observed_bands[vis][band]['maxfreq']=maxfreq
          observed_bands[vis][band]['minfreq']=minfreq
          observed_bands[vis][band]['fracbw']=fracbw
+
+         msmd.open(vis)
+         observed_bands[vis][band]['ncorrs']=msmd.ncorrforpol(msmd.polidfordatadesc(spwarray[vis][0]))
+         msmd.close()
    get_max_uvdist(vislist,observed_bands[vislist[0]]['bands'].copy(),observed_bands)
    return bands,observed_bands
 
@@ -1726,6 +1730,10 @@ def get_VLA_bands(vislist,fields):
          spwstring=','.join(str(spw) for spw in spwslist)
          observed_bands[vis][band]['spwstring']=spwstring+''
          observed_bands[vis][band]['meanfreq'],observed_bands[vis][band]['maxfreq'],observed_bands[vis][band]['minfreq'],observed_bands[vis][band]['fracbw']=get_mean_freq([vis],{vis: [observed_bands[vis][band]['spwarray']]})
+
+         msmd.open(vis)
+         observed_bands[vis][band]['ncorrs']=msmd.ncorrforpol(msmd.polidfordatadesc(observed_bands[vis][band]['spwarray'][0]))
+         msmd.close()
    bands_match=True
    for i in range(len(vislist)):
       for j in range(i+1,len(vislist)):


### PR DESCRIPTION
It turns out that for single polarization datasets, if gaintype='G' is set for gaincal the resulting table will still have both polarizations but the missing one will be entirely flagged. This interacts badly with our flagged fraction calculations as it shows 50% flagging (or more) for all antennas even though those solutions aren't expected in the first place.

This PR is to track the polarization setup of a dataset (single-pol, dual-pol, full-pol) in the metadata gathering stage, and also fixes the flagging reporting by setting inf_EB_gaintype='T' for single-pol datasets so that only a single solution is generated.