### PR TITLE
Add the option to run findcont prior to selfcal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ TempLattice*
 .*.swp
 
 applycal_to_orig_MSes.py
+
+oussid*
+pipeline*
+flux.csv
+cont.dat
+casacalls*

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -80,8 +80,20 @@ apply_to_target_ms=False # apply final selfcal solutions back to the input _targ
 sort_targets_and_EBs=False
 run_findcont=True
 
+if run_findcont and os.path.exists("cont.dat"):
+    if np.any([len(parse_contdotdat('cont.dat',target)) == 0 for target in all_targets]):
+        if not os.path.exists("cont.dat.original"):
+            print("Found existing cont.dat, but it is missing targets. Backing that up to cont.dat.original")
+            os.system("mv cont.dat cont.dat.original")
+        else:
+            print("Found existing cont.dat, but it is missing targets. A backup of the original (cont.dat.original) already exists, so not backing up again.")
+    elif run_findcont:
+        print("cont.dat already exists and includes all targets, so running findcont is not needed. Continuing...")
+        run_findcont=False
+
 if run_findcont:
     try:
+        print("Running findcont")
         h_init()
         hifa_importdata(vis=vislist, dbservice=False)
         hif_checkproductsize(maxcubesize=60.0, maxcubelimit=70.0, maxproductsize=4000.0)

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -78,7 +78,7 @@ dividing_factor=-99.0  # number that the peak SNR is divided by to determine fir
 check_all_spws=False   # generate per-spw images to check phase transfer did not go poorly for narrow windows
 apply_to_target_ms=False # apply final selfcal solutions back to the input _target.ms files
 sort_targets_and_EBs=False
-run_findcont=True
+run_findcont=False
 
 if run_findcont and os.path.exists("cont.dat"):
     if np.any([len(parse_contdotdat('cont.dat',target)) == 0 for target in all_targets]):

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -93,6 +93,11 @@ if run_findcont and os.path.exists("cont.dat"):
 
 if run_findcont:
     try:
+        if 'pipeline' not in sys.modules:
+            print("Pipeline found but not imported. Importing...")
+            import pipeline
+            pipeline.initcli()
+
         print("Running findcont")
         h_init()
         hifa_importdata(vis=vislist, dbservice=False)

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -78,6 +78,18 @@ dividing_factor=-99.0  # number that the peak SNR is divided by to determine fir
 check_all_spws=False   # generate per-spw images to check phase transfer did not go poorly for narrow windows
 apply_to_target_ms=False # apply final selfcal solutions back to the input _target.ms files
 sort_targets_and_EBs=False
+run_findcont=True
+
+if run_findcont:
+    try:
+        h_init()
+        hifa_importdata(vis=vislist, dbservice=False)
+        hif_checkproductsize(maxcubesize=60.0, maxcubelimit=70.0, maxproductsize=4000.0)
+        hif_makeimlist(specmode="mfs")
+        hif_findcont()
+    except:
+        print("\nWARNING: Cannot run findcont as the pipeline was not found. Please retry with a CASA version that includes the pipeline or start CASA with the --pipeline flag.\n")
+        sys.exit(0)
 
 if sort_targets_and_EBs:
     all_targets.sort()


### PR DESCRIPTION
This PR adds the ability to run findcont prior to running self-calibration. This is particularly useful for the case where multi-object tracks had mitigation done such that not all targets had findcont run on them and therefore do not have continuum ranges. The parameters set to avoid mitigation are somewhat arbitrary and may need to be updated at some point, but are intended to allow lots of products of up to a relatively large size. They may not help large mosaics that failed because the cubes themselves were just too large.