### PR TITLE
Ensure that the clean threshold for the final image is never higher than the clean threshold for the initial image

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -452,7 +452,7 @@ for target in all_targets:
             sensitivity=sensitivity   #*4.0  might be unnecessary with DR mods
       else:
          sensitivity=0.0
-      tclean_wrapper(vislist,sani_target+'_'+band+'_initial',
+      initial_tclean_return = tclean_wrapper(vislist,sani_target+'_'+band+'_initial',
                      band_properties,band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold=str(sensitivity*4.0)+'Jy',
                      savemodel='none',parallel=parallel,cellsize=cellsize[target][band],imsize=imsize[target][band],nterms=nterms[target][band],
@@ -483,9 +483,7 @@ for target in all_targets:
       selfcal_library[target][band]['clean_threshold_orig']=sensitivity*4.0
    if 'VLA' in telescope:
       selfcal_library[target][band]['theoretical_sensitivity']=-99.0
-      with open(sani_target+'_'+band+'_initial.return.pickle', 'rb') as handle:
-          initial_tclean_return = pickle.load(handle)
-          selfcal_library[target][band]['clean_threshold_orig']=initial_tclean_return['summaryminor'][0][0][0]['peakRes'][-1]
+      selfcal_library[target][band]['clean_threshold_orig']=initial_tclean_return['summaryminor'][0][0][0]['peakRes'][-1]
    selfcal_library[target][band]['SNR_orig']=initial_SNR
    if selfcal_library[target][band]['nterms'] == 1:  # updated nterms if needed based on S/N and fracbw
       selfcal_library[target][band]['nterms']=check_image_nterms(selfcal_library[target][band]['fracbw'],selfcal_library[target][band]['SNR_orig'])

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -483,7 +483,7 @@ for target in all_targets:
       selfcal_library[target][band]['clean_threshold_orig']=sensitivity*4.0
    if 'VLA' in telescope:
       selfcal_library[target][band]['theoretical_sensitivity']=-99.0
-      with open('Target_K04169_Band_6_initial.return.pickle', 'rb') as handle:
+      with open(sani_target+'_'+band+'_initial.return.pickle', 'rb') as handle:
           initial_tclean_return = pickle.load(handle)
           selfcal_library[target][band]['clean_threshold_orig']=initial_tclean_return['summaryminor'][0][0][0]['peakRes'][-1]
    selfcal_library[target][band]['SNR_orig']=initial_SNR

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -811,7 +811,7 @@ for target in all_targets:
    if selfcal_library[target][band]['clean_threshold_orig'] < selfcal_library[target][band]['RMS_NF_curr']*3.0:
        print("WARNING: The clean threshold used for the initial image was less than 3*RMS_NF_curr, using that for the final image threshold instead.")
    tclean_wrapper(vislist,sani_target+'_'+band+'_final',\
-               band_properties,band,telescope=telescope,nsigma=3.0, threshold=str(clean_threshold*3.0)+'Jy',scales=[0],\
+               band_properties,band,telescope=telescope,nsigma=3.0, threshold=str(clean_threshold)+'Jy',scales=[0],\
                savemodel='none',parallel=parallel,cellsize=cellsize[target][band],imsize=imsize[target][band],
                nterms=selfcal_library[target][band]['nterms'],field=target,datacolumn='corrected',spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], \
                nfrms_multiplier=nfsnr_modifier, image_mosaic_fields_separately=selfcal_library[target][band]['obstype']=='mosaic', \

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy 
 import scipy.stats
 import scipy.signal
-import pickle
 import math
 import os
 
@@ -147,9 +146,6 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                startmodel=startmodel,
                datacolumn=datacolumn,spw=spw,wprojplanes=wprojplanes, verbose=True)
 
-        with open(imagename+'.return.pickle', 'wb') as handle:
-            pickle.dump(tclean_return, handle, protocol=pickle.HIGHEST_PROTOCOL)
-
         if image_mosaic_fields_separately:
             for field_id in mosaic_field_phasecenters:
                 if 'VLA' in telescope:
@@ -243,6 +239,8 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                  parallel=False,
                  phasecenter=phasecenter,spw=spw,wprojplanes=wprojplanes)
     
+    if not savemodel_only:
+        return tclean_return
 
 
 def collect_listobs_per_vis(vislist):

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2,6 +2,7 @@ import numpy as np
 import numpy 
 import scipy.stats
 import scipy.signal
+import pickle
 import math
 import os
 
@@ -110,7 +111,7 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
         if not resume:
             for ext in ['.image*', '.mask', '.model*', '.pb*', '.psf*', '.residual*', '.sumwt*','.gridwt*']:
                 os.system('rm -rf '+ imagename + ext)
-        tclean(vis= vis, 
+        tclean_return = tclean(vis= vis, 
                imagename = imagename, 
                field=field,
                specmode = 'mfs', 
@@ -145,6 +146,9 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                phasecenter=phasecenter,
                startmodel=startmodel,
                datacolumn=datacolumn,spw=spw,wprojplanes=wprojplanes, verbose=True)
+
+        with open(imagename+'.return.pickle', 'wb') as handle:
+            pickle.dump(tclean_return, handle, protocol=pickle.HIGHEST_PROTOCOL)
 
         if image_mosaic_fields_separately:
             for field_id in mosaic_field_phasecenters:


### PR DESCRIPTION
It turns out that due to the way that the clean threshold for the initial image is calculated (from the theoretical sensitivity with a DR-modifier) compared with the way the clean threshold for the final image is calculated (from 3*RMS_NF_curr as calculated from the post solint images), it can occasionally be the case that the clean threshold for the final image is higher than the clean threshold for the initial image. This can lead to oddities such as apparent increases in the RMS of the final image or decrease of the SNR, simply because the final image is not being cleaned as deeply as the initial image.

To fix this issue, this PR adds a condition that the final image clean threshold should be `min(selfcal_library[target][band]['clean_threshold_orig'], 3*selfcal_library[target][band]['RMS_NF_curr']` so that we fall back to matching the initial image in the event that the RMS would be a higher threshold. We also now track `'clean_threshold_orig'` so that this is possible. 

For VLA datasets, where the initial clean threshold is not set by DR modifiers but is rather cleaned to nsigma=4, we use the results of the tclean return dictionary (which is now saved) to find the peak residual at the end of the final major cycle and use this as a proxy for the initial clean threshold (as it should be <= the original clean threshold). Unfortunately the actual threshold used is not stored, but this should be close enough.