### PR TITLE
Skip inf in the event of two scans with one much longer than the other

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -523,7 +523,7 @@ def get_solints_simple(vislist,scantimesdict,scanstartsdict,scanendsdict,integra
    gaincal_combine.insert(0,inf_EB_gaincal_combine)
 
    #insert solint = inf
-   if median_scans_per_obs > 1:                    # if only a single scan per target, redundant with inf_EB and do not include
+   if median_scans_per_obs > 2 or (median_scans_per_obs == 2 and max_scantime / min_scantime < 4):                    # if only a single scan per target, redundant with inf_EB and do not include
       solints_list.append('inf')
       if spwcombine:
          gaincal_combine.append('spw')


### PR DESCRIPTION
I've noticed that selfcal can sometimes have issues when it runs into a dataset where a target has a long scan followed by a much shorter scan. I suspect the issue arises because applycal ends up interpolating between gaincal solutions derived from very different averaging times, though I don't know this for certain. One solution to this issue that appears to work is to skip the inf solint such that it goes straight to dividing up the longer scan into several intervals.

As this PR currently stands, it explicitly looks for cases where there are two scans, though I wonder if it makes sense to extend to any case where max_scan_time >> min_scan_time? Possibly something to think about.

~~And there should be time as it currently cannot be merged automatically.~~ << Fixed