### PR TITLE
Use the gaincal return dictionary to calculate the fraction of solutions flagged per antenna for the calonly fallback purposes

### DIFF
--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -370,7 +370,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                            else:
                               spwselect=selfcal_library[target][band][vis]['spws']
                            print('Running gaincal on '+spwselect+' for '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
-                           gaincal(vis=vis,\
+                           gaincal_return = gaincal(vis=vis,\
                              caltable=sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g',\
                              gaintype=gaincal_gaintype, spw=spwselect,
                              refant=selfcal_library[target][band][vis]['refant'], calmode=solmode[band][target][iteration], solnorm=solnorm if applymode=="calflag" else False,
@@ -425,7 +425,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                             else:
                                 splinetime = float(splinetime[0:-1])
 
-                        gaincal(vis=vis,\
+                        gaincal_return = gaincal(vis=vis,\
                              #caltable=sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g',\
                              caltable="temp.g",\
                              gaintype=gaincal_gaintype, spw=selfcal_library[target][band][fid][vis]['spws'],
@@ -474,7 +474,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                                     unflag_spwmap = []
 
                                 unflag_failed_antennas(vis, sani_target+'_'+vis+'_'+band+'_'+sint+'_'+str(it)+'_'+\
-                                        solmode[band][target][it]+'.g', flagged_fraction=0.25, solnorm=solnorm, \
+                                        solmode[band][target][it]+'.g', selfcal_library[target][band][vis][sint]['gaincal_return'], flagged_fraction=0.25, solnorm=solnorm, \
                                         only_long_baselines=solmode[band][target][it]=="ap" if unflag_only_lbants and \
                                         unflag_only_lbants_onlyap else unflag_only_lbants, calonly_max_flagged=calonly_max_flagged, \
                                         spwmap=unflag_spwmap, fb_to_prev_solint=unflag_fb_to_prev_solint, solints=solints[band][target], iteration=it)
@@ -502,7 +502,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                       else:
                          spwselect=','.join(str(spw) for spw in spws_set[band][vis][i].tolist())
 
-                      gaincal(vis=vis,\
+                      test_gaincal_return = gaincal(vis=vis,\
                         caltable='test_inf_EB.g',\
                         gaintype=gaincal_gaintype, spw=spwselect,
                         refant=selfcal_library[target][band][vis]['refant'], calmode='p', 
@@ -521,6 +521,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                          applycal_spwmap[vis]=[selfcal_library[target][band][vis]['spwmap']]
                          os.system('rm -rf           '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
                          os.system('mv test_inf_EB.g '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
+                         gaincal_return = test_gaincal_return
                       if fallback[vis] =='spwmap':
                          gaincal_spwmap[vis]=applycal_spwmap_inf_EB
                          inf_EB_gaincal_combine_dict[target][band][vis]='scan'
@@ -535,6 +536,8 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                           selfcal_library[target][band][fid][vis][solint]['gaincal_combine']=gaincal_combine[band][target][iteration]+''
 
                    os.system('rm -rf test_inf_EB.g')               
+
+                selfcal_library[target][band][vis][solint]['gaincal_return'] = gaincal_return
 
                 # If iteration two, try restricting to just the antennas with enough unflagged data.
                 # Should we also restrict to just long baseline antennas?
@@ -553,7 +556,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                     selfcal_library[target][band][vis][solint]['unflagged_lbs'] = True
 
                     unflag_failed_antennas(vis, sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+\
-                            solmode[band][target][iteration]+'.g', flagged_fraction=0.25, solnorm=solnorm, \
+                            solmode[band][target][iteration]+'.g', selfcal_library[target][band][vis][solint]['gaincal_return'], flagged_fraction=0.25, solnorm=solnorm, \
                             only_long_baselines=solmode[band][target][iteration]=="ap" if unflag_only_lbants and unflag_only_lbants_onlyap else \
                             unflag_only_lbants, calonly_max_flagged=calonly_max_flagged, spwmap=unflag_spwmap, \
                             fb_to_prev_solint=unflag_fb_to_prev_solint, solints=solints[band][target], iteration=iteration)

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2923,11 +2923,9 @@ def unflag_failed_antennas(vis, caltable, gaincal_return, flagged_fraction=0.25,
     good_spws = np.logical_and(good_spws, good_antennas)
  
     antennas = antennas[good_spws]
-    """
     flags = flags[:,:,good_spws]
     cals = cals[:,:,good_spws]
     snr = snr[:,:,good_spws]
-    """
 
     # Get the percentage of flagged solutions for each antenna.
     unique_antennas = np.unique(antennas)
@@ -2939,11 +2937,11 @@ def unflag_failed_antennas(vis, caltable, gaincal_return, flagged_fraction=0.25,
 
     nflagged = np.array([[(gaincal_return['solvestats']['spw'+str(spw)]['ant'+str(ant)]["data_unflagged"].sum() - 
             gaincal_return['solvestats']['spw'+str(spw)]['ant'+str(ant)]["above_minsnr"].sum()) for ant in good_antenna_ids] 
-            for spw in gaincal_return['selectvis']['spw']])
+            for spw in good_spw_ids])
     nsolutions = np.array([[gaincal_return['solvestats']['spw'+str(spw)]['ant'+str(ant)]["data_unflagged"].sum() 
             for ant in good_antenna_ids] for spw in good_spw_ids])
 
-    percentage_flagged = nflagged.sum(axis=0) / nsolutions.sum(axis=0)
+    percentage_flagged = nflagged.sum(axis=0) / np.clip(nsolutions.sum(axis=0), 1., np.inf)
 
  
     # Load in the positions of the antennas and calculate their offsets from the geometric center.

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2576,7 +2576,7 @@ def render_per_solint_QA_pages(sclib,solints,bands,directory='weblog'):
                plot_ants_flagging_colored(directory+'/images/plot_ants_'+gaintable+'.png',vis,gaintable)
                htmlOutSolint.writelines('<a href="images/plot_ants_'+gaintable+'.png"><img src="images/plot_ants_'+gaintable+'.png" ALT="antenna positions with flagging plot" WIDTH=400 HEIGHT=400></a>')
                if 'unflagged_lbs' in sclib[target][band][vis][solints[band][target][i]]:
-                   unflag_failed_antennas(vis, gaintable.replace('.g','.pre-pass.g'), flagged_fraction=0.25, \
+                   unflag_failed_antennas(vis, gaintable.replace('.g','.pre-pass.g'), sclib[target][band][vis][solints[band][target][i]]['gaincal_return'], flagged_fraction=0.25, \
                            spwmap=sclib[target][band][vis][solints[band][target][i]]['unflag_spwmap'], \
                            plot=True, plot_directory=directory+'/images/')
                    htmlOutSolint.writelines('\n<a href="images/'+gaintable.replace('.g.','.pre-pass.pass')+'.png"><img src="images/'+gaintable.replace('.g','.pre-pass.pass')+'.png" ALT="Long baseline unflagging thresholds" HEIGHT=400></a><br>\n')
@@ -2895,7 +2895,7 @@ def analyze_inf_EB_flagging(selfcal_library,band,spwlist,gaintable,vis,target,sp
 
 
 
-def unflag_failed_antennas(vis, caltable, flagged_fraction=0.25, only_long_baselines=False, solnorm=True, calonly_max_flagged=0., spwmap=[], 
+def unflag_failed_antennas(vis, caltable, gaincal_return, flagged_fraction=0.25, only_long_baselines=False, solnorm=True, calonly_max_flagged=0., spwmap=[], 
         fb_to_prev_solint=False, solints=[], iteration=0, plot=False, plot_directory="./"):
     tb.open(caltable, nomodify=plot) # Because we only modify if we aren't plotting, i.e. in the selfcal loop itself plot=False
     antennas = tb.getcol("ANTENNA1")
@@ -2906,9 +2906,11 @@ def unflag_failed_antennas(vis, caltable, flagged_fraction=0.25, only_long_basel
     if len(spwmap) > 0:
         spws = tb.getcol("SPECTRAL_WINDOW_ID")
         good_spws = np.repeat(False, spws.size)
-        for spw in np.unique(spwmap):
+        good_spw_ids = np.unique(spwmap)
+        for spw in good_spw_ids:
             good_spws = np.logical_or(good_spws, spws == spw)
     else:
+        good_spw_ids = gaincal_return['selectvis']['spw']
         good_spws = np.repeat(True, antennas.size)
 
     msmd.open(vis)
@@ -2921,15 +2923,28 @@ def unflag_failed_antennas(vis, caltable, flagged_fraction=0.25, only_long_basel
     good_spws = np.logical_and(good_spws, good_antennas)
  
     antennas = antennas[good_spws]
+    """
     flags = flags[:,:,good_spws]
     cals = cals[:,:,good_spws]
     snr = snr[:,:,good_spws]
+    """
 
     # Get the percentage of flagged solutions for each antenna.
     unique_antennas = np.unique(antennas)
     nants = unique_antennas.size
+    """
     ordered_flags = flags.reshape(flags.shape[0:2] + (flags.shape[2]//nants, nants))
     percentage_flagged = (ordered_flags.sum(axis=2) / ordered_flags.shape[2]).mean(axis=0).mean(axis=0)
+    """
+
+    nflagged = np.array([[(gaincal_return['solvestats']['spw'+str(spw)]['ant'+str(ant)]["data_unflagged"].sum() - 
+            gaincal_return['solvestats']['spw'+str(spw)]['ant'+str(ant)]["above_minsnr"].sum()) for ant in good_antenna_ids] 
+            for spw in gaincal_return['selectvis']['spw']])
+    nsolutions = np.array([[gaincal_return['solvestats']['spw'+str(spw)]['ant'+str(ant)]["data_unflagged"].sum() 
+            for ant in good_antenna_ids] for spw in good_spw_ids])
+
+    percentage_flagged = nflagged.sum(axis=0) / nsolutions.sum(axis=0)
+
  
     # Load in the positions of the antennas and calculate their offsets from the geometric center.
     msmd.open(vis)


### PR DESCRIPTION
The gaincal return dictionary provides more detailed information about which gain solutions were actually flagged by gaincal rather than being flagged prior to the task by some other mechanism, and so it provides a better way of calculating the fraction of solutions flagged per antenna by the gaincal task. This PR therefore switches the function `unflag_failed_antennas` from parsing the gaintable itself to using the gaincal return dictionary to calculate the fraction of flagged antennas.