### PR TITLE
Fix what happens when inf_EB succeeds with a decrease in SNR and then inf fails for mosaics

### DIFF
--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1094,6 +1094,8 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                     else:
                         for vis in selfcal_library[target][band][fid]['vislist']:
                             selfcal_library[target][band][fid][vis][solint]['Pass']=False
+                        if solint == 'inf_EB':
+                            selfcal_library[target][band][fid]['inf_EB_SNR_decrease']=False
 
                 # To exit out of the applymode loop.
                 break
@@ -1207,9 +1209,12 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                 for vis in vislist:
                    selfcal_library[target][band][vis]['inf_EB']['Pass']=False    #  remove the success from inf_EB
                 
+             # Only set the inf_EB Pass flag to False if the mosaic as a whole failed or if this is the last phase-only solint (either because it is int or
+             # because the solint failed, because for mosaics we can keep trying the field as we clean deeper. If we set to False now, that wont happen.
              for fid in np.intersect1d(selfcal_library[target][band]['sub-fields'],list(selfcal_library[target][band]['sub-fields-fid_map'][vis].keys())):
-                if (selfcal_library[target][band][fid]['final_solint'] == 'inf_EB' and selfcal_library[target][band][fid]['inf_EB_SNR_decrease']) or 
-                      (selfcal_library[target][band]['final_solint'] == 'inf_EB' and selfcal_library[target][band]['inf_EB_SNR_decrease']):
+                if (selfcal_library[target][band]['final_solint'] == 'inf_EB' and selfcal_library[target][band]['inf_EB_SNR_decrease']) or \
+                        ((not selfcal_library[target][band][vislist[0]][solint]['Pass'] or solint == 'int') and \
+                        (selfcal_library[target][band][fid]['final_solint'] == 'inf_EB' and selfcal_library[target][band][fid]['inf_EB_SNR_decrease'])):
                    selfcal_library[target][band][fid]['SC_success']=False
                    selfcal_library[target][band][fid]['final_solint']='None'
                    for vis in vislist:

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1073,9 +1073,9 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                     if field_by_field_success[ind]:
                         selfcal_library[target][band][fid]['SC_success']=True
                         selfcal_library[target][band][fid]['Stop_Reason']='None'
-                        if (solint =='inf_EB') and (((post_SNR-SNR)/SNR < 0.0) or ((post_SNR_NF - SNR_NF)/SNR_NF < 0.0)):
+                        if (solint =='inf_EB') and not strict_field_by_field_success[ind]:
                            selfcal_library[target][band][fid]['inf_EB_SNR_decrease']=True
-                        elif (solint =='inf_EB') and (((post_SNR-SNR)/SNR > 0.0) and ((post_SNR_NF - SNR_NF)/SNR_NF > 0.0)):
+                        elif (solint =='inf_EB') and strict_field_by_field_success[ind]:
                            selfcal_library[target][band][fid]['inf_EB_SNR_decrease']=False
 
                         for vis in selfcal_library[target][band][fid]['vislist']:
@@ -1206,11 +1206,14 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                 selfcal_library[target][band]['final_solint']='None'
                 for vis in vislist:
                    selfcal_library[target][band][vis]['inf_EB']['Pass']=False    #  remove the success from inf_EB
-                for fid in np.intersect1d(selfcal_library[target][band]['sub-fields'],list(selfcal_library[target][band]['sub-fields-fid_map'][vis].keys())):
-                   if selfcal_library[target][band][fid]['final_solint'] == 'inf_EB' and selfcal_library[target][band][fid]['inf_EB_SNR_decrease']:
-                      selfcal_library[target][band][fid]['SC_success']=False
-                      for vis in vislist:
-                         selfcal_library[target][band][fid][vis]['inf_EB']['Pass']=False    #  remove the success from inf_EB
+                
+             for fid in np.intersect1d(selfcal_library[target][band]['sub-fields'],list(selfcal_library[target][band]['sub-fields-fid_map'][vis].keys())):
+                if (selfcal_library[target][band][fid]['final_solint'] == 'inf_EB' and selfcal_library[target][band][fid]['inf_EB_SNR_decrease']) or 
+                      (selfcal_library[target][band]['final_solint'] == 'inf_EB' and selfcal_library[target][band]['inf_EB_SNR_decrease']):
+                   selfcal_library[target][band][fid]['SC_success']=False
+                   selfcal_library[target][band][fid]['final_solint']='None'
+                   for vis in vislist:
+                      selfcal_library[target][band][fid][vis]['inf_EB']['Pass']=False    #  remove the success from inf_EB
 
              for vis in vislist:
                  flagmanager(vis=vis,mode='restore',versionname='selfcal_starting_flags_'+sani_target)


### PR DESCRIPTION
The code was recently updated to clear all calibrations in the event that inf_EB succeeds with a minor decrease in SNR but then the inf solint fails so that we don't end up accepting the inf_EB solutions that actually made the data worse. Those updates, though need a little tweaking to work a bit better with mosaics. The updates in this PR are to:

1. Check on a field-by-field basis whether the SNR decreased for _that field_ for inf_EB, rather than for the mosaic as a whole.
2. In the event that either the SNR decreased _for that field_ from inf_EB and then inf failed _for that field_, **or** the SNR decreased for the mosaic as a whole and then inf failed for the mosaic as a whole, fail both the inf_EB and the inf solints for that field. This is consistent with the overall mosaic success criteria of SNR must increase for both the mosaic as a whole and for any given field for that field to be considered successful.