### PR TITLE
Calculate better reffreq for nterms=2 images

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -108,7 +108,7 @@ dividing_factor=-99.0  # number that the peak SNR is divided by to determine fir
                        # default is 40 for <8ghz and 15.0 for all other frequencies
 check_all_spws=False   # generate per-spw images to check phase transfer did not go poorly for narrow windows
 apply_to_target_ms=False # apply final selfcal solutions back to the input _target.ms files
-sort_targets_and_EBs=False
+sort_targets_and_EBs=True
 run_findcont=False
 debug=False
 
@@ -215,8 +215,8 @@ for target in all_targets:
           cellsize[target][band],imsize[target][band],nterms[target][band],reffreq[target][band] = \
                   get_image_parameters(vislist,telescope,target,dict(zip(vislist,[mosaic_field[band][vis][target]['field_ids'] for vis in vislist])),band, \
                   band_properties,scale_fov=scale_fov,mosaic=mosaic_field[band][vislist[0]][target]['mosaic'])
-
-       print("Reffreq = ",reffreq[target][band])
+       if band in reffreq[target].keys():
+          print("Reffreq = ",reffreq[target][band])
 
        if band_properties[vislist[0]][band]['meanfreq'] >12.0e9:
           applycal_interp[target][band]='linearPD'

--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -205,15 +205,18 @@ for vis in vislist:
 cellsize={}
 imsize={}
 nterms={}
+reffreq={}
 applycal_interp={}
 
 for target in all_targets:
-    cellsize[target], imsize[target], nterms[target], applycal_interp[target] = {}, {}, {}, {}
+    cellsize[target], imsize[target], nterms[target], reffreq[target], applycal_interp[target] = {}, {}, {}, {}, {}
     for band in bands:
        if target in mosaic_field[band][vislist[0]].keys():
-          cellsize[target][band],imsize[target][band],nterms[target][band] = \
-                  get_image_parameters(vislist,telescope,target,band, \
+          cellsize[target][band],imsize[target][band],nterms[target][band],reffreq[target][band] = \
+                  get_image_parameters(vislist,telescope,target,dict(zip(vislist,[mosaic_field[band][vis][target]['field_ids'] for vis in vislist])),band, \
                   band_properties,scale_fov=scale_fov,mosaic=mosaic_field[band][vislist[0]][target]['mosaic'])
+
+       print("Reffreq = ",reffreq[target][band])
 
        if band_properties[vislist[0]][band]['meanfreq'] >12.0e9:
           applycal_interp[target][band]='linearPD'
@@ -334,6 +337,7 @@ for target in all_targets:
    selfcal_library[target][band]['spws']=[]
    selfcal_library[target][band]['spws_per_vis']=[]
    selfcal_library[target][band]['nterms']=nterms[target][band]
+   selfcal_library[target][band]['reffreq']=reffreq[target][band]
    selfcal_library[target][band]['vislist']=vislist.copy()
    allscantimes=np.array([])
    allscannfields=np.array([])
@@ -388,6 +392,7 @@ for target in all_targets:
        selfcal_library[target][band][fid]['spws']=[]
        selfcal_library[target][band][fid]['spws_per_vis']=[]
        selfcal_library[target][band][fid]['nterms']=nterms[target][band]
+       selfcal_library[target][band][fid]['reffreq']=reffreq[target][band]
        selfcal_library[target][band][fid]['vislist']=[vis for vis in vislist if fid in selfcal_library[target][band]['sub-fields-fid_map'][vis]]
        selfcal_library[target][band][fid]['obstype'] = 'single-point'
        allscantimes=np.array([])
@@ -477,7 +482,7 @@ for target in all_targets:
       tclean_wrapper(vislist,sani_target+'_'+band+'_dirty',
                      band_properties,band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold='0.0Jy',niter=1, gain=0.00001,
-                     savemodel='none',parallel=parallel,cellsize=cellsize[target][band],imsize=imsize[target][band],nterms=nterms[target][band],
+                     savemodel='none',parallel=parallel,cellsize=cellsize[target][band],imsize=imsize[target][band],nterms=nterms[target][band],reffreq=reffreq[target][band],
                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], image_mosaic_fields_separately=selfcal_library[target][band]['obstype']=='mosaic', mosaic_field_phasecenters=selfcal_library[target][band]['sub-fields-phasecenters'], mosaic_field_fid_map=selfcal_library[target][band]['sub-fields-fid_map'],mask=sourcemask,usermodel='')
    dirty_SNR,dirty_RMS=estimate_SNR(sani_target+'_'+band+'_dirty.image.tt0')
    if telescope!='ACA' or aca_use_nfmask:
@@ -522,7 +527,7 @@ for target in all_targets:
       initial_tclean_return = tclean_wrapper(vislist,sani_target+'_'+band+'_initial',
                      band_properties,band,telescope=telescope,nsigma=4.0, scales=[0],
                      threshold=str(sensitivity*4.0)+'Jy',
-                     savemodel='none',parallel=parallel,cellsize=cellsize[target][band],imsize=imsize[target][band],nterms=nterms[target][band],
+                     savemodel='none',parallel=parallel,cellsize=cellsize[target][band],imsize=imsize[target][band],nterms=nterms[target][band],reffreq=reffreq[target][band],
                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], nfrms_multiplier=dirty_NF_RMS/dirty_RMS, image_mosaic_fields_separately=selfcal_library[target][band]['obstype']=='mosaic', mosaic_field_phasecenters=selfcal_library[target][band]['sub-fields-phasecenters'], mosaic_field_fid_map=selfcal_library[target][band]['sub-fields-fid_map'], cyclefactor=selfcal_library[target][band]['cyclefactor'],mask=sourcemask,usermodel='')
    initial_SNR,initial_RMS=estimate_SNR(sani_target+'_'+band+'_initial.image.tt0')
    if telescope!='ACA' or aca_use_nfmask:
@@ -900,7 +905,7 @@ for target in all_targets:
    tclean_wrapper(vislist,sani_target+'_'+band+'_final',\
                band_properties,band,telescope=telescope,nsigma=3.0, threshold=str(clean_threshold)+'Jy',scales=[0],\
                savemodel='none',parallel=parallel,cellsize=cellsize[target][band],imsize=imsize[target][band],
-               nterms=selfcal_library[target][band]['nterms'],field=target,datacolumn='corrected',spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], \
+               nterms=selfcal_library[target][band]['nterms'],reffreq=selfcal_library[target][band]['reffreq'],field=target,datacolumn='corrected',spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], \
                nfrms_multiplier=nfsnr_modifier, image_mosaic_fields_separately=selfcal_library[target][band]['obstype']=='mosaic', \
                mosaic_field_phasecenters=selfcal_library[target][band]['sub-fields-phasecenters'], mosaic_field_fid_map=selfcal_library[target][band]['sub-fields-fid_map'],\
                cyclefactor=selfcal_library[target][band]['cyclefactor'],mask=sourcemask,usermodel='')

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -40,7 +40,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                      band_properties,band,telescope=telescope,nsigma=0.0, scales=[0],
                      threshold='0.0Jy',
                      savemodel='modelcolumn',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
-                     nterms=selfcal_library[target][band]['nterms'],
+                     nterms=selfcal_library[target][band]['nterms'],reffreq=selfcal_library[target][band]['reffreq'],
                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], resume=False, image_mosaic_fields_separately=selfcal_library[target][band]['obstype'] == 'mosaic', mosaic_field_phasecenters=selfcal_library[target][band]['sub-fields-phasecenters'], mosaic_field_fid_map=selfcal_library[target][band]['sub-fields-fid_map'], cyclefactor=selfcal_library[target][band]['cyclefactor'],mask=mask,usermodel=usermodel)
 
    for iteration in range(len(solints[band][target])):
@@ -100,7 +100,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                      band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
                      threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_NF_curr'])+'Jy',
                      savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
-                     nterms=selfcal_library[target][band]['nterms'],
+                     nterms=selfcal_library[target][band]['nterms'],reffreq=selfcal_library[target][band]['reffreq'],
                      field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], nfrms_multiplier=nfsnr_modifier, resume=resume, image_mosaic_fields_separately=selfcal_library[target][band]['obstype'] == 'mosaic', mosaic_field_phasecenters=selfcal_library[target][band]['sub-fields-phasecenters'], mosaic_field_fid_map=selfcal_library[target][band]['sub-fields-fid_map'], cyclefactor=selfcal_library[target][band]['cyclefactor'],mask=mask,usermodel=usermodel)
 
          # Check that a mask was actually created, because if not the model will be empty and gaincal will do bad things and the 
@@ -137,7 +137,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                              band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
                              threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_NF_curr'])+'Jy',
                              savemodel='modelcolumn',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
-                             nterms=selfcal_library[target][band]['nterms'],
+                             nterms=selfcal_library[target][band]['nterms'],reffreq=selfcal_library[target][band]['reffreq'],
                              field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], nfrms_multiplier=nfsnr_modifier, savemodel_only=True, cyclefactor=selfcal_library[target][band]['cyclefactor'],mask=mask,usermodel=usermodel)
 
              for vis in vislist:
@@ -720,7 +720,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                       band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
                       threshold=str(selfcal_library[target][band]['nsigma'][iteration]*selfcal_library[target][band]['RMS_NF_curr'])+'Jy',
                       savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
-                      nterms=selfcal_library[target][band]['nterms'],
+                      nterms=selfcal_library[target][band]['nterms'],reffreq=selfcal_library[target][band]['reffreq'],
                       field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], nfrms_multiplier=nfsnr_modifier, image_mosaic_fields_separately=selfcal_library[target][band]['obstype'] == 'mosaic', mosaic_field_phasecenters=selfcal_library[target][band]['sub-fields-phasecenters'], mosaic_field_fid_map=selfcal_library[target][band]['sub-fields-fid_map'], cyclefactor=selfcal_library[target][band]['cyclefactor'],mask=mask,usermodel=usermodel)
 
              ##
@@ -968,7 +968,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                           band_properties,band,telescope=telescope,nsigma=selfcal_library[target][band]['nsigma'][iteration], scales=[0],
                           threshold=str(selfcal_library[target][band][vislist[0]][solint]['clean_threshold'])+'Jy',
                           savemodel='none',parallel=parallel,cellsize=cellsize[band],imsize=imsize[band],
-                          nterms=selfcal_library[target][band]['nterms'],
+                          nterms=selfcal_library[target][band]['nterms'],reffreq=selfcal_library[target][band]['reffreq'],
                           field=target,spw=selfcal_library[target][band]['spws_per_vis'],uvrange=selfcal_library[target][band]['uvrange'],obstype=selfcal_library[target][band]['obstype'], nfrms_multiplier=nfsnr_modifier, image_mosaic_fields_separately=False, mosaic_field_phasecenters=selfcal_library[target][band]['sub-fields-phasecenters'], mosaic_field_fid_map=selfcal_library[target][band]['sub-fields-fid_map'], cyclefactor=selfcal_library[target][band]['cyclefactor'],mask=mask,usermodel=usermodel)
 
                  ##


### PR DESCRIPTION
When there are uneven distributions of SPW bandwidths (e.g. one wide window at the extremes with a collection of narrow windows), nterms=2 imaging can degrade the quality of the image when it uses its default SPW-center-average as the reference frequency for the Taylor expansion. This PR fixes that by calculating the per-SPW total weights of the unflagged data, and using those total weights to do a weighted average of the SPW centers. This way, wider-bandwidth SPWs get more weight naturally, but it also accounts for cases where the noise in wide bandwidth SPWs degrades due to poor atmospheric transmission.

@jjtobin - I've tested this on the few problematic cases that led to this ticket, but do you think it would be worth running tests on a few normal datasets before merging? I forget how many of our regression tests end up with nterms = 2, but may be worth running a round of that?