### PR TITLE
Scale the threshold number of flagged antennas for doing an inf_EB fallback based on the number of antennas

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -3017,7 +3017,7 @@ def analyze_inf_EB_flagging(selfcal_library,band,spwlist,gaintable,vis,target,sp
    #want the widest bandwidth window that also has the minimum flags to use for spw mapping
    applycal_spwmap=[]
    if fallback=='spwmap':
-      minflagged_index=(np.array(nflags)/2.0 == minimum_flagged_ants_per_spw).nonzero()
+      minflagged_index=(np.array(nflags) == minimum_flagged_ants_per_spw).nonzero()
       max_bw_index = (eff_bws == np.max(eff_bws[minflagged_index[0]])).nonzero()
       max_bw_min_flags_index=np.intersect1d( minflagged_index[0],max_bw_index[0])
       #if len(max_bw_min_flags_index) > 1:


### PR DESCRIPTION
Because the ACA has overall fewer antennas, the hard-coded threshold of 2 antennas needing to be flagged in a SPW means that ~20% of data needs to be flagged before combining SPWs would be considered. This is a much larger fraction than, say, for the main array, where 2/45 ~ 4.5%, and can lead to more significant reductions in the RMS per-spw for the ACA than we typically see for main array data. This PR updates this to scale the number of antennas needing to be flagged based on that 2/45 for the main array by the number of antennas in a given array.

Also of note @jjtobin, because tclean won't use data where one of the polarizations is flagged, this update now considers an antenna entirely flagged if one of the polarizations is flagged. The only two places that code is used are in `analyze_inf_EB_flagging` and in plotting the fraction of flagged antennas. So with this update, we won't have any 50% flagging for, e.g. combinespw solutions where one pol is flagged but not the other. This isn't technically correct because only 50% of the solutions are actually flagged. On the other hand, if the unflagged pol isn't being used in tclean, then perhaps this is actually a more "correct" way of reporting? 

In any case, I want to get your feedback on that as it will be a side effect as this currently stands. I can definitely make the code capable of differentiating the two uses, this was just the minimally invasive way of making this update. Thoughts?

I've also only tested this on one dataset at this point, so I'm going to try to test it a bit more broadly before we actually accept.