### PR TITLE
add precheck boolean for inf_EB to determine if it will attempt inf following marginal inf_EB

### DIFF
--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1051,7 +1051,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                         selfcal_library[target][band][vis][solint]['intflux_post'],selfcal_library[target][band][vis][solint]['e_intflux_post']=-99.0,-99.0
 
              #run a pre-check as to whether a marginal inf_EB result will go on to attempt inf, if not we will fail a marginal inf_EB
-             if ((solint =='inf_EB') and ((post_SNR-SNR)/SNR > -0.02) and ((post_SNR_NF - SNR_NF)/SNR_NF > -0.02) and (delta_beamarea < delta_beam_thresh))):
+             if (solint =='inf_EB') and ((post_SNR-SNR)/SNR > -0.02) and ((post_SNR_NF - SNR_NF)/SNR_NF > -0.02) and (delta_beamarea < delta_beam_thresh):
                 if (selfcal_library[target][band][vis][solint]['SNR_post'] >  selfcal_library[target][band]['SNR_orig']):
                    print('Updating solint = '+solints[band][target][iteration+1]+' SNR')
                    print('Was: ',solint_snr[target][band][solints[band][target][iteration+1]])
@@ -1061,7 +1061,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                        print('Field '+str(fid)+' Was: ',solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]])
                        get_SNR_self_update([target],band,vislist,selfcal_library[target][band][fid],n_ants,solint,solints[band][target][iteration+1],integration_time,solint_snr_per_field[target][band][fid])
                        print('Field '+str(fid)+' Now: ',solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]])
-                if solint_snr[target][band][solints[band][target][iteration+1]] < minsnr_to_proceed and np.all([solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]] < minsnr_to_proceed
+                if solint_snr[target][band][solints[band][target][iteration+1]] < minsnr_to_proceed and  np.all([solint_snr_per_field[target][band][fid][solints[band][target][iteration]] < minsnr_to_proceed for fid in selfcal_library[target][band]['sub-fields']]):
                    marginal_inf_EB_will_attempt_next_solint = False
                 else:
                    marginal_inf_EB_will_attempt_next_solint =  True

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1051,20 +1051,12 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                         selfcal_library[target][band][vis][solint]['intflux_post'],selfcal_library[target][band][vis][solint]['e_intflux_post']=-99.0,-99.0
 
              #run a pre-check as to whether a marginal inf_EB result will go on to attempt inf, if not we will fail a marginal inf_EB
-             if (solint =='inf_EB') and ((post_SNR-SNR)/SNR > -0.02) and ((post_SNR_NF - SNR_NF)/SNR_NF > -0.02) and (delta_beamarea < delta_beam_thresh):
-                if (selfcal_library[target][band][vis][solint]['SNR_post'] >  selfcal_library[target][band]['SNR_orig']):
-                   print('Updating solint = '+solints[band][target][iteration+1]+' SNR')
-                   print('Was: ',solint_snr[target][band][solints[band][target][iteration+1]])
-                   get_SNR_self_update([target],band,vislist,selfcal_library[target][band],n_ants,solint,solints[band][target][iteration+1],integration_time,solint_snr[target][band])
-                   print('Now: ',solint_snr[target][band][solints[band][target][iteration+1]])
-                   for fid in selfcal_library[target][band]['sub-fields-to-selfcal']:
-                       print('Field '+str(fid)+' Was: ',solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]])
-                       get_SNR_self_update([target],band,vislist,selfcal_library[target][band][fid],n_ants,solint,solints[band][target][iteration+1],integration_time,solint_snr_per_field[target][band][fid])
-                       print('Field '+str(fid)+' Now: ',solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]])
-                if solint_snr[target][band][solints[band][target][iteration+1]] < minsnr_to_proceed and  np.all([solint_snr_per_field[target][band][fid][solints[band][target][iteration]] < minsnr_to_proceed for fid in selfcal_library[target][band]['sub-fields']]):
+             if (solint =='inf_EB') and ((post_SNR-SNR)/SNR > -0.02) and ((post_SNR-SNR)/SNR < 0.00) and ((post_SNR_NF - SNR_NF)/SNR_NF > -0.02) and ((post_SNR_NF - SNR_NF)/SNR_NF < 0.00) and (delta_beamarea < delta_beam_thresh):
+                if solint_snr[target][band][solints[band][target][iteration+1]] < minsnr_to_proceed and np.all([solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]] < minsnr_to_proceed for fid in selfcal_library[target][band]['sub-fields']]):
                    marginal_inf_EB_will_attempt_next_solint = False
                 else:
                    marginal_inf_EB_will_attempt_next_solint =  True
+
 
              if (((post_SNR >= SNR) and (post_SNR_NF >= SNR_NF) and (delta_beamarea < delta_beam_thresh)) or ((solint =='inf_EB') and marginal_inf_EB_will_attempt_next_solint and ((post_SNR-SNR)/SNR > -0.02) and ((post_SNR_NF - SNR_NF)/SNR_NF > -0.02) and (delta_beamarea < delta_beam_thresh))) and np.any(field_by_field_success): 
                 selfcal_library[target][band]['SC_success']=True

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1062,11 +1062,11 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                        get_SNR_self_update([target],band,vislist,selfcal_library[target][band][fid],n_ants,solint,solints[band][target][iteration+1],integration_time,solint_snr_per_field[target][band][fid])
                        print('Field '+str(fid)+' Now: ',solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]])
                 if solint_snr[target][band][solints[band][target][iteration+1]] < minsnr_to_proceed and np.all([solint_snr_per_field[target][band][fid][solints[band][target][iteration+1]] < minsnr_to_proceed
-                   marginal_inf_EB_will_attempt_inf = False
+                   marginal_inf_EB_will_attempt_next_solint = False
                 else:
-                   marginal_inf_EB_will_attempt_inf =  True
+                   marginal_inf_EB_will_attempt_next_solint =  True
 
-             if (((post_SNR >= SNR) and (post_SNR_NF >= SNR_NF) and (delta_beamarea < delta_beam_thresh)) or ((solint =='inf_EB') and marginal_inf_EB_will_attempt_inf and ((post_SNR-SNR)/SNR > -0.02) and ((post_SNR_NF - SNR_NF)/SNR_NF > -0.02) and (delta_beamarea < delta_beam_thresh))) and np.any(field_by_field_success): 
+             if (((post_SNR >= SNR) and (post_SNR_NF >= SNR_NF) and (delta_beamarea < delta_beam_thresh)) or ((solint =='inf_EB') and marginal_inf_EB_will_attempt_next_solint and ((post_SNR-SNR)/SNR > -0.02) and ((post_SNR_NF - SNR_NF)/SNR_NF > -0.02) and (delta_beamarea < delta_beam_thresh))) and np.any(field_by_field_success): 
                 selfcal_library[target][band]['SC_success']=True
                 selfcal_library[target][band]['Stop_Reason']='None'
                 #keep track of whether inf_EB had a S/N decrease


### PR DESCRIPTION
If a marginal inf_EB case, an up to 2% S/N decrease, is to be regarded as a 'pass', then it must also have enough S/N to attempt the next solution interval (inf or otherwise). This boolean adds a pre-check to ensure that it has enough S/N to go on before regarding it as a pass.