### PR TITLE
Collect (and properly use) all gaincal returns in instances where gaincal is run more than once with append=True

### DIFF
--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -370,6 +370,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                     selfcal_library[target][band][vis][solint]["include_scans"] = include_scans
                     selfcal_library[target][band][vis][solint]["include_targets"] = include_targets
 
+                    selfcal_library[target][band][vis][solint]['gaincal_return'] = []
                     for incl_scans, incl_targets in zip(include_scans, include_targets):
                         if solint == 'inf_EB':
                            if spws_set[band][vis].ndim == 1:
@@ -387,7 +388,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                            else:
                               spwselect=selfcal_library[target][band][vis]['spws']
                            print('Running gaincal on '+spwselect+' for '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
-                           gaincal_return = gaincal(vis=vis,\
+                           gaincal_return_tmp = gaincal(vis=vis,\
                              caltable=sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g',\
                              gaintype=gaincal_gaintype, spw=spwselect,
                              refant=selfcal_library[target][band][vis]['refant'], calmode=solmode[band][target][iteration], solnorm=solnorm if applymode=="calflag" else False,
@@ -395,9 +396,11 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                              field=incl_targets,scan=incl_scans,gaintable=gaincal_preapply_gaintable[vis],spwmap=gaincal_spwmap[vis],uvrange=selfcal_library[target][band]['uvrange'],
                              interp=gaincal_interpolate[vis], solmode=gaincal_solmode, refantmode='flex', append=os.path.exists(sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g'))
                            #
+                           selfcal_library[target][band][vis][solint]['gaincal_return'].append(gaincal_return_tmp)
                            if solint != 'inf_EB':
                               break
                 else:
+                    selfcal_library[target][band][vis][solint]['gaincal_return'] = []
                     for fid in np.intersect1d(selfcal_library[target][band]['sub-fields-to-selfcal'],list(selfcal_library[target][band]['sub-fields-fid_map'][vis].keys())):
                         gaincal_spwmap[vis]=[]
                         gaincal_preapply_gaintable[vis]=selfcal_library[target][band][fid][vis][selfcal_library[target][band][fid]['final_phase_solint']]['gaintable']
@@ -442,7 +445,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                             else:
                                 splinetime = float(splinetime[0:-1])
 
-                        gaincal_return = gaincal(vis=vis,\
+                        gaincal_return_tmp = gaincal(vis=vis,\
                              #caltable=sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g',\
                              caltable="temp.g",\
                              gaintype=gaincal_gaintype, spw=selfcal_library[target][band][fid][vis]['spws'],
@@ -452,6 +455,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                              #interp=gaincal_interpolate[vis], solmode=gaincal_solmode, append=os.path.exists(sani_target+'_'+vis+'_'+band+'_'+
                              #solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g'))
                              interp=gaincal_interpolate[vis], solmode=gaincal_solmode, append=os.path.exists('temp.g'), refantmode='flex')
+                        selfcal_library[target][band][vis][solint]['gaincal_return'].append(gaincal_return_tmp)
 
                     tb.open("temp.g")
                     subt = tb.query("OBSERVATION_ID==0", sortlist="TIME,ANTENNA1")
@@ -513,18 +517,19 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                    test_gaincal_combine='scan,spw'
                    if selfcal_library[target][band]['obstype']=='mosaic':
                       test_gaincal_combine+=',field'   
+                   test_gaincal_return = []
                    for i in range(spws_set[band][vis].shape[0]):  # run gaincal on each spw set to handle spectral scans
                       if nspw_sets == 1 and spws_set[band][vis].ndim == 1:
                          spwselect=','.join(str(spw) for spw in spws_set[band][vis].tolist())
                       else:
                          spwselect=','.join(str(spw) for spw in spws_set[band][vis][i].tolist())
 
-                      test_gaincal_return = gaincal(vis=vis,\
+                      test_gaincal_return += [gaincal(vis=vis,\
                         caltable='test_inf_EB.g',\
                         gaintype=gaincal_gaintype, spw=spwselect,
                         refant=selfcal_library[target][band][vis]['refant'], calmode='p', 
                         solint=solint.replace('_EB','').replace('_ap',''),minsnr=gaincal_minsnr if applymode == "calflag" else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=test_gaincal_combine,
-                        field=include_targets[0],gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode=refantmode,append=os.path.exists('test_inf_EB.g')) 
+                        field=include_targets[0],gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode=refantmode,append=os.path.exists('test_inf_EB.g'))]
                    spwlist=selfcal_library[target][band][vis]['spws'].split(',')
                    fallback[vis],map_index,spwmap,applycal_spwmap_inf_EB=analyze_inf_EB_flagging(selfcal_library,band,spwlist,sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g',vis,target,'test_inf_EB.g',spectral_scan,telescope)
 
@@ -538,7 +543,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                          applycal_spwmap[vis]=[selfcal_library[target][band][vis]['spwmap']]
                          os.system('rm -rf           '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
                          os.system('mv test_inf_EB.g '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
-                         gaincal_return = test_gaincal_return
+                         selfcal_library[target][band][vis][solint]['gaincal_return'] = test_gaincal_return
                       if fallback[vis] =='spwmap':
                          gaincal_spwmap[vis]=applycal_spwmap_inf_EB
                          inf_EB_gaincal_combine_dict[target][band][vis]='scan'
@@ -554,7 +559,6 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
 
                    os.system('rm -rf test_inf_EB.g')               
 
-                selfcal_library[target][band][vis][solint]['gaincal_return'] = gaincal_return
 
                 # If iteration two, try restricting to just the antennas with enough unflagged data.
                 # Should we also restrict to just long baseline antennas?

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -3166,7 +3166,7 @@ def unflag_failed_antennas(vis, caltable, gaincal_return, flagged_fraction=0.25,
         for spw in good_spw_ids:
             good_spws = np.logical_or(good_spws, spws == spw)
     else:
-        good_spw_ids = gaincal_return['selectvis']['spw']
+        good_spw_ids = np.unique(np.concatenate([gcdict['selectvis']['spw'] for gcdict in gaincal_return]))
         good_spws = np.repeat(True, antennas.size)
 
     msmd.open(vis)
@@ -3191,10 +3191,10 @@ def unflag_failed_antennas(vis, caltable, gaincal_return, flagged_fraction=0.25,
     percentage_flagged = (ordered_flags.sum(axis=2) / ordered_flags.shape[2]).mean(axis=0).mean(axis=0)
     """
 
-    nflagged = np.array([[(gaincal_return['solvestats']['spw'+str(spw)]['ant'+str(ant)]["data_unflagged"].sum() - 
-            gaincal_return['solvestats']['spw'+str(spw)]['ant'+str(ant)]["above_minsnr"].sum()) for ant in good_antenna_ids] 
+    nflagged = np.array([[np.sum([gcdict['solvestats']['spw'+str(spw)]['ant'+str(ant)]["data_unflagged"].sum() - 
+            gcdict['solvestats']['spw'+str(spw)]['ant'+str(ant)]["above_minsnr"].sum() for gcdict in gaincal_return]) for ant in good_antenna_ids] 
             for spw in good_spw_ids])
-    nsolutions = np.array([[gaincal_return['solvestats']['spw'+str(spw)]['ant'+str(ant)]["data_unflagged"].sum() 
+    nsolutions = np.array([[np.sum([gcdict['solvestats']['spw'+str(spw)]['ant'+str(ant)]["data_unflagged"].sum() for gcdict in gaincal_return]) 
             for ant in good_antenna_ids] for spw in good_spw_ids])
 
     percentage_flagged = nflagged.sum(axis=0) / np.clip(nsolutions.sum(axis=0), 1., np.inf)


### PR DESCRIPTION
PR #38 introduced using the gaincal return dictionary to get flagging statistics for a gaintable and use those in lieu of reading the gaintable directly when doing the unflagging of long baseline antennas. The motivation was the the gaincal return dictionary provides greater detail about the reason for flagging and in particular whether the flagging was due to gaincal itself or whether the data was already flagged, a priori.

That PR, however, only accounted for the possibility that gaincal was run once for any given gaintable, while in reality, spectral scan datasets (and additional future use cases) may call gaincal multiple times with append=True. This PR now collects the return dictionary from all gaincal calls and also properly uses it to calculate flagged fraction when doing the unflagging of long baselines.