### PR TITLE
Add combinespwpol with gaintype='T' as a possible fallback mode for inf_EB

### DIFF
--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -543,12 +543,12 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                          inf_EB_gaincal_combine_dict[target][band][vis]='scan,spw'
                          applycal_spwmap[vis]=[selfcal_library[target][band][vis]['spwmap']]
                          os.system('rm -rf           '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
+                         for gaintype in np.unique([gaincal_gaintype,'T']):
+                            os.system('cp -r test_inf_EB_'+gaintype+'.g '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.gaintype'+gaintype+'.g')
                          if fallback[vis] == 'combinespw':
                              gaincal_gaintype = 'G'
                          else:
                              gaincal_gaintype = 'T'
-                         for gaintype in np.unique([gaincal_gaintype,'T']):
-                            os.system('cp -r test_inf_EB_'+gaintype+'.g '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.gaintype'+gaintype+'.g')
                          os.system('mv test_inf_EB_'+gaincal_gaintype+'.g '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
                          selfcal_library[target][band][vis][solint]['gaincal_return'] = test_gaincal_return[gaincal_gaintype]
                       if fallback[vis] =='spwmap':

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -530,7 +530,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                             gaintype=gaintype, spw=spwselect,
                             refant=selfcal_library[target][band][vis]['refant'], calmode='p', 
                             solint=solint.replace('_EB','').replace('_ap',''),minsnr=gaincal_minsnr if applymode == "calflag" else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=test_gaincal_combine,
-                            field=include_targets[0],gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode=refantmode,append=os.path.exists('test_inf_EB.g'))]
+                            field=include_targets[0],gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode=refantmode,append=os.path.exists('test_inf_EB_'+gaintype+'.g'))]
                    spwlist=selfcal_library[target][band][vis]['spws'].split(',')
                    fallback[vis],map_index,spwmap,applycal_spwmap_inf_EB=analyze_inf_EB_flagging(selfcal_library,band,spwlist,sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g',vis,target,'test_inf_EB_'+gaincal_gaintype+'.g',spectral_scan,telescope,'test_inf_EB_T.g' if gaincal_gaintype=='G' else None)
 

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -517,33 +517,40 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                    test_gaincal_combine='scan,spw'
                    if selfcal_library[target][band]['obstype']=='mosaic':
                       test_gaincal_combine+=',field'   
-                   test_gaincal_return = []
-                   for i in range(spws_set[band][vis].shape[0]):  # run gaincal on each spw set to handle spectral scans
-                      if nspw_sets == 1 and spws_set[band][vis].ndim == 1:
-                         spwselect=','.join(str(spw) for spw in spws_set[band][vis].tolist())
-                      else:
-                         spwselect=','.join(str(spw) for spw in spws_set[band][vis][i].tolist())
+                   test_gaincal_return = {'G':[], 'T':[]}
+                   for gaintype in np.unique([gaincal_gaintype,'T']):
+                       for i in range(spws_set[band][vis].shape[0]):  # run gaincal on each spw set to handle spectral scans
+                          if nspw_sets == 1 and spws_set[band][vis].ndim == 1:
+                             spwselect=','.join(str(spw) for spw in spws_set[band][vis].tolist())
+                          else:
+                             spwselect=','.join(str(spw) for spw in spws_set[band][vis][i].tolist())
 
-                      test_gaincal_return += [gaincal(vis=vis,\
-                        caltable='test_inf_EB.g',\
-                        gaintype=gaincal_gaintype, spw=spwselect,
-                        refant=selfcal_library[target][band][vis]['refant'], calmode='p', 
-                        solint=solint.replace('_EB','').replace('_ap',''),minsnr=gaincal_minsnr if applymode == "calflag" else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=test_gaincal_combine,
-                        field=include_targets[0],gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode=refantmode,append=os.path.exists('test_inf_EB.g'))]
+                          test_gaincal_return[gaintype] += [gaincal(vis=vis,\
+                            caltable='test_inf_EB_'+gaintype+'.g',\
+                            gaintype=gaintype, spw=spwselect,
+                            refant=selfcal_library[target][band][vis]['refant'], calmode='p', 
+                            solint=solint.replace('_EB','').replace('_ap',''),minsnr=gaincal_minsnr if applymode == "calflag" else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=test_gaincal_combine,
+                            field=include_targets[0],gaintable='',spwmap=[],uvrange=selfcal_library[target][band]['uvrange'], refantmode=refantmode,append=os.path.exists('test_inf_EB.g'))]
                    spwlist=selfcal_library[target][band][vis]['spws'].split(',')
-                   fallback[vis],map_index,spwmap,applycal_spwmap_inf_EB=analyze_inf_EB_flagging(selfcal_library,band,spwlist,sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g',vis,target,'test_inf_EB.g',spectral_scan,telescope)
+                   fallback[vis],map_index,spwmap,applycal_spwmap_inf_EB=analyze_inf_EB_flagging(selfcal_library,band,spwlist,sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g',vis,target,'test_inf_EB_'+gaincal_gaintype+'.g',spectral_scan,telescope,'test_inf_EB_T.g' if gaincal_gaintype=='G' else None)
 
                    inf_EB_fallback_mode_dict[target][band][vis]=fallback[vis]+''
                    print('inf_EB',fallback[vis],applycal_spwmap_inf_EB)
                    if fallback[vis] != '':
-                      if fallback[vis] =='combinespw':
+                      if 'combinespw' in fallback[vis]:
                          gaincal_spwmap[vis]=[selfcal_library[target][band][vis]['spwmap']]
                          gaincal_combine[band][target][iteration]='scan,spw'
                          inf_EB_gaincal_combine_dict[target][band][vis]='scan,spw'
                          applycal_spwmap[vis]=[selfcal_library[target][band][vis]['spwmap']]
                          os.system('rm -rf           '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
-                         os.system('mv test_inf_EB.g '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
-                         selfcal_library[target][band][vis][solint]['gaincal_return'] = test_gaincal_return
+                         if fallback[vis] == 'combinespw':
+                             gaincal_gaintype = 'G'
+                         else:
+                             gaincal_gaintype = 'T'
+                         for gaintype in np.unique([gaincal_gaintype,'T']):
+                            os.system('cp -r test_inf_EB_'+gaintype+'.g '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.gaintype'+gaintype+'.g')
+                         os.system('mv test_inf_EB_'+gaincal_gaintype+'.g '+sani_target+'_'+vis+'_'+band+'_'+solint+'_'+str(iteration)+'_'+solmode[band][target][iteration]+'.g')
+                         selfcal_library[target][band][vis][solint]['gaincal_return'] = test_gaincal_return[gaincal_gaintype]
                       if fallback[vis] =='spwmap':
                          gaincal_spwmap[vis]=applycal_spwmap_inf_EB
                          inf_EB_gaincal_combine_dict[target][band][vis]='scan'
@@ -557,7 +564,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                           selfcal_library[target][band][fid][vis][solint]['spwmap']=applycal_spwmap[vis]
                           selfcal_library[target][band][fid][vis][solint]['gaincal_combine']=gaincal_combine[band][target][iteration]+''
 
-                   os.system('rm -rf test_inf_EB.g')               
+                   os.system('rm -rf test_inf_EB_*.g')               
 
 
                 # If iteration two, try restricting to just the antennas with enough unflagged data.

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2847,6 +2847,8 @@ def render_per_solint_QA_pages(sclib,solints,bands,directory='weblog'):
                         fallback_mode='Combine SPW'
                      if sclib[target][band][vis][solints[band][target][i]]['fallback'] == 'spwmap':
                         fallback_mode='SPWMAP'
+                     if sclib[target][band][vis][solints[band][target][i]]['fallback'] == 'combinespwpol':
+                        fallback_mode='Combine SPW & Pol'
                      htmlOutSolint.writelines('<h4>Fallback Mode: <font color="red">'+fallback_mode+'</font></h4>\n')
                htmlOutSolint.writelines('<h4>Spwmapping: ['+' '.join(map(str,sclib[target][band][vis][solints[band][target][i]]['spwmap']))+']</h4>\n')
 
@@ -3055,7 +3057,7 @@ def get_phasecenter(vis,field):
    phasecenter_string='ICRS {:0.8f}rad {:0.8f}rad '.format(ra_phasecenter,dec_phasecenter)
    return phasecenter_string
 
-def get_flagged_solns_per_spw(spwlist,gaintable):
+def get_flagged_solns_per_spw(spwlist,gaintable,extendpol=False):
      # Get the antenna names and offsets.
      msmd = casatools.msmetadata()
      tb = casatools.table()
@@ -3064,19 +3066,27 @@ def get_flagged_solns_per_spw(spwlist,gaintable):
      #gaintable='"'+gaintable+'"'
      os.system('cp -r '+gaintable.replace(' ','\ ')+' tempgaintable.g')
      gaintable='tempgaintable.g'
-     nflags = [tb.calc('[select from '+gaintable+' where SPECTRAL_WINDOW_ID=='+\
-             spwlist[i]+' giving  [ntrue(FLAG)]]')['0'].sum() for i in \
-             range(len(spwlist))]
-     nunflagged = [tb.calc('[select from '+gaintable+' where SPECTRAL_WINDOW_ID=='+\
-             spwlist[i]+' giving  [nfalse(FLAG)]]')['0'].sum() for i in \
-             range(len(spwlist))]
+     if extendpol:
+         nflags = [tb.calc('[select from '+gaintable+' where SPECTRAL_WINDOW_ID=='+\
+                 spwlist[i]+' giving  [any(FLAG)]]')['0'].sum() for i in \
+                 range(len(spwlist))]
+         nunflagged = [tb.calc('[select from '+gaintable+' where SPECTRAL_WINDOW_ID=='+\
+                 spwlist[i]+' giving  [nfalse(any(FLAG))]]')['0'].sum() for i in \
+                 range(len(spwlist))]
+     else:
+         nflags = [tb.calc('[select from '+gaintable+' where SPECTRAL_WINDOW_ID=='+\
+                 spwlist[i]+' giving  [ntrue(FLAG)]]')['0'].sum() for i in \
+                 range(len(spwlist))]
+         nunflagged = [tb.calc('[select from '+gaintable+' where SPECTRAL_WINDOW_ID=='+\
+                 spwlist[i]+' giving  [nfalse(FLAG)]]')['0'].sum() for i in \
+                 range(len(spwlist))]
      os.system('rm -rf tempgaintable.g')
      fracflagged=np.array(nflags)/(np.array(nflags)+np.array(nunflagged))
      # Calculate a score based on those two.
      return nflags, nunflagged,fracflagged
 
 
-def analyze_inf_EB_flagging(selfcal_library,band,spwlist,gaintable,vis,target,spw_combine_test_gaintable,spectral_scan,telescope):
+def analyze_inf_EB_flagging(selfcal_library,band,spwlist,gaintable,vis,target,spw_combine_test_gaintable,spectral_scan,telescope,spwpol_combine_test_gaintable=None):
    if telescope != 'ACA':
        # if more than two antennas are fully flagged relative to the combinespw results, fallback to combinespw
        max_flagged_ants_combspw=2.0
@@ -3152,6 +3162,15 @@ def analyze_inf_EB_flagging(selfcal_library,band,spwlist,gaintable,vis,target,sp
       # always fallback to combinespw for spectral scans
       if fallback !='' and spectral_scan:
          fallback='combinespw'
+
+   # If we end up with combinespw, check whether going to combinespw with gaintype='T' offers further improvement.
+   nflags_spwcomb,nunflagged_spwcomb,fracflagged_spwcomb=get_flagged_solns_per_spw([spwlist[0]],spw_combine_test_gaintable,extendpol=True)
+   nflags_spwpolcomb,nunflagged_spwpolcomb,fracflagged_spwpolcomb=get_flagged_solns_per_spw([spwlist[0]],spwpol_combine_test_gaintable)
+
+   if np.sqrt((nunflagged_spwcomb[0]*(nunflagged_spwcomb[0]-1)) / (nunflagged_spwpolcomb[0]*(nunflagged_spwpolcomb[0]-1))) < 0.95:
+       fallback='combinespwpol'
+
+
    return fallback,map_index,spwmap,applycal_spwmap
 
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -3163,12 +3163,13 @@ def analyze_inf_EB_flagging(selfcal_library,band,spwlist,gaintable,vis,target,sp
       if fallback !='' and spectral_scan:
          fallback='combinespw'
 
-   # If we end up with combinespw, check whether going to combinespw with gaintype='T' offers further improvement.
-   nflags_spwcomb,nunflagged_spwcomb,fracflagged_spwcomb=get_flagged_solns_per_spw([spwlist[0]],spw_combine_test_gaintable,extendpol=True)
-   nflags_spwpolcomb,nunflagged_spwpolcomb,fracflagged_spwpolcomb=get_flagged_solns_per_spw([spwlist[0]],spwpol_combine_test_gaintable)
+   if fallback == "combinespw":
+      # If we end up with combinespw, check whether going to combinespw with gaintype='T' offers further improvement.
+      nflags_spwcomb,nunflagged_spwcomb,fracflagged_spwcomb=get_flagged_solns_per_spw([spwlist[0]],spw_combine_test_gaintable,extendpol=True)
+      nflags_spwpolcomb,nunflagged_spwpolcomb,fracflagged_spwpolcomb=get_flagged_solns_per_spw([spwlist[0]],spwpol_combine_test_gaintable)
 
-   if np.sqrt((nunflagged_spwcomb[0]*(nunflagged_spwcomb[0]-1)) / (nunflagged_spwpolcomb[0]*(nunflagged_spwpolcomb[0]-1))) < 0.95:
-       fallback='combinespwpol'
+      if np.sqrt((nunflagged_spwcomb[0]*(nunflagged_spwcomb[0]-1)) / (nunflagged_spwpolcomb[0]*(nunflagged_spwpolcomb[0]-1))) < 0.95:
+          fallback='combinespwpol'
 
 
    return fallback,map_index,spwmap,applycal_spwmap


### PR DESCRIPTION
This PR adds an additional gaintable to check for the inf_EB solint where combine="spw,scan" and gaintype='T' (instead of gaintype='G'), i.e. combining the polarizations in one last attempt to boost SNR. This mode is invoked in the event that the expected SNR increase from combining polarizations (i.e. by not losing as many antennas) is > X%. X = 5 currently.

@jjtobin - creating this pull request now, but testing is ongoing to see how this impacts a broader range of datasets and to check whether we need to adjust the thresholds at all.