### PR TITLE
Check whether the RMS increases by more than 5% as a criteria for a solint to succeed

### DIFF
--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -919,18 +919,26 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
              strict_field_by_field_success = []
              loose_field_by_field_success = []
              beam_field_by_field_success = []
+             rms_field_by_field_success = []
              for fid in selfcal_library[target][band]['sub-fields-to-selfcal']:
                  strict_field_by_field_success += [(post_mosaic_SNR[fid] >= mosaic_SNR[fid]) and (post_mosaic_SNR_NF[fid] >= mosaic_SNR_NF[fid])]
                  loose_field_by_field_success += [((post_mosaic_SNR[fid]-mosaic_SNR[fid])/mosaic_SNR[fid] > -0.02) and \
                          ((post_mosaic_SNR_NF[fid] - mosaic_SNR_NF[fid])/mosaic_SNR_NF[fid] > -0.02)]
                  beam_field_by_field_success += [delta_beamarea < delta_beam_thresh]
+                 rms_field_by_field_success = ((post_mosaic_RMS[fid] - mosaic_RMS[fid])/mosaic_RMS[fid] < 1.05 and \
+                         (post_mosaic_RMS_NF[fid] - mosaic_RMS_NF[fid])/mosaic_RMS_NF[fid] < 1.05) or \
+                         (((post_mosaic_RMS[fid] - mosaic_RMS[fid])/mosaic_RMS[fid] > 1.05 or \
+                         (post_mosaic_RMS_NF[fid] - mosaic_RMS_NF[fid])/mosaic_RMS_NF[fid] > 1.05) and \
+                         solint_snr_per_field[target][band][fid][solint] > 5)
 
              if solint == 'inf_EB':
                  # If any of the fields succeed in the "strict" sense, then allow for minor reductions in the evaluation quantity in other
                  # fields because there's a good chance that those are just noise being pushed around.
-                 field_by_field_success = numpy.logical_and(loose_field_by_field_success, beam_field_by_field_success)
+                 field_by_field_success = numpy.logical_and(numpy.logical_and(loose_field_by_field_success, beam_field_by_field_success), \
+                         rms_field_by_field_success)
              else:
-                 field_by_field_success = numpy.logical_and(strict_field_by_field_success, beam_field_by_field_success)
+                 field_by_field_success = numpy.logical_and(numpy.logical_and(strict_field_by_field_success, beam_field_by_field_success), \
+                         rms_field_by_field_success)
 
              # If not all fields were successful, we need to make an additional image to evaluate whether the image as a whole improved,
              # otherwise the _post image won't be exactly representative.
@@ -1062,8 +1070,10 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                 else:
                    marginal_inf_EB_will_attempt_next_solint =  True
 
+             RMS_change_acceptable = (post_RMS/RMS < 1.05 and post_RMS_NF/RMS_NF < 1.05) or \
+                     ((post_RMS/RMS > 1.05 or post_RMS_NF/RMS_NF > 1.05) and solint_snr[target][band][solint] > 5)
 
-             if (((post_SNR >= SNR) and (post_SNR_NF >= SNR_NF) and (delta_beamarea < delta_beam_thresh)) or ((solint =='inf_EB') and marginal_inf_EB_will_attempt_next_solint and ((post_SNR-SNR)/SNR > -0.02) and ((post_SNR_NF - SNR_NF)/SNR_NF > -0.02) and (delta_beamarea < delta_beam_thresh))) and np.any(field_by_field_success): 
+             if (((post_SNR >= SNR) and (post_SNR_NF >= SNR_NF) and (delta_beamarea < delta_beam_thresh)) or ((solint =='inf_EB') and marginal_inf_EB_will_attempt_next_solint and ((post_SNR-SNR)/SNR > -0.02) and ((post_SNR_NF - SNR_NF)/SNR_NF > -0.02) and (delta_beamarea < delta_beam_thresh))) and np.any(field_by_field_success) and RMS_change_acceptable: 
                 selfcal_library[target][band]['SC_success']=True
                 selfcal_library[target][band]['Stop_Reason']='None'
                 #keep track of whether inf_EB had a S/N decrease

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1181,6 +1181,14 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                if reason !='':
                   reason=reason+'; '
                reason=reason+'Beam change beyond '+str(delta_beam_thresh)
+            if (post_RMS/RMS > 1.05 and solint_snr[target][band][solint] <= 5):
+               if reason != '':
+                  reason=reason+'; '
+               reason=reason+'RMS increase beyond 5%'
+            if (post_RMS_NF/RMS_NF > 1.05 and solint_snr[target][band][solint] <= 5):
+               if reason != '':
+                  reason=reason+'; '
+               reason=reason+'NF RMS increase beyond 5%'
             if not np.any(field_by_field_success):
                 if reason != '':
                     reason=reason+'; '
@@ -1206,6 +1214,14 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                     if mosaic_reason[fid] !='':
                        mosaic_reason[fid]=mosaic_reason[fid]+'; '
                     mosaic_reason[fid]=mosaic_reason[fid]+'Beam change beyond '+str(delta_beam_thresh)
+                 if (post_RMS/RMS > 1.05 and solint_snr[target][band][solint] <= 5):
+                    if mosaic_reason[fid] != '':
+                       mosaic_reason[fid]=mosaic_reason[fid]+'; '
+                    mosaic_reason[fid]=mosaic_reason[fid]+'RMS increase beyond 5%'
+                 if (post_RMS_NF/RMS_NF > 1.05 and solint_snr[target][band][solint] <= 5):
+                    if mosaic_reason[fid] != '':
+                       mosaic_reason[fid]=mosaic_reason[fid]+'; '
+                    mosaic_reason[fid]=mosaic_reason[fid]+'NF RMS increase beyond 5%'
                  if mosaic_reason[fid] == '':
                      mosaic_reason[fid] = "Global selfcal failed"
                  selfcal_library[target][band][fid]['Stop_Reason']=mosaic_reason[fid]


### PR DESCRIPTION
There can be some pathalogical cases where the SNR increases in spite of large increases in the RMS. This is ok if we have reason to believe that the flagging, which leads to the increase in the RMS, is warranted (e.g. we expect high SNR solutions but aren't getting them). But in the event that it may not be warranted (e.g. we are in the low SNR regime to begin with), it is better to fail the solint than to accept the significant RMS increase.

This PR adds a check for RMS increases, coupled with a low expected SNR, as a reason to fail a solint.