### PR TITLE
Generalize split_calibrated_final to work with any MS file.

### DIFF
--- a/split_calibrated_final.py
+++ b/split_calibrated_final.py
@@ -30,7 +30,7 @@ for vis in vislist:
                 continue
 
         split(vis, outputvis=outputvis, observation=i, intent="*OBSERVE_TARGET*", \
-                spw=','.join(np.intersect1d(msmd.spwsforscan(msmd.scansforintent("*OBSERVE_TARGET*", obsid=0)[0], obsid=0), \
+                spw=','.join(np.intersect1d(msmd.spwsforscan(msmd.scansforintent("*OBSERVE_TARGET*", obsid=i)[0], obsid=i), \
                 np.concatenate((msmd.tdmspws(),msmd.fdmspws()))).astype(str)), \
                 antenna=','.join(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*", obsid=i)[0], obsid=i).astype(str)), \
                 datacolumn=datacolumn)

--- a/split_calibrated_final.py
+++ b/split_calibrated_final.py
@@ -1,12 +1,37 @@
 from casatools import msmetadata as msmdtool
+from casatools import table as tbtool
+import glob
+import os
+import numpy as np
 
 msmd = msmdtool()
+tb = tbtool()
 
-msmd.open("calibrated_final.ms")
-for i in range(msmd.nobservations()):
-    split("calibrated_final.ms", outputvis=msmd.schedule(i)[1].split(" ")[1].replace("/","_").replace(":","_")+"_targets.ms", \
-            observation=i, intent="*OBSERVE_TARGET*", \
-            spw=','.join(msmd.spwsforscan(msmd.scansforintent("*OBSERVE_TARGET*", obsid=i)[0], obsid=i).astype(str)), \
-            antenna=','.join(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*", obsid=i)[0], obsid=i).astype(str)), \
-            datacolumn="data")
-msmd.close()
+vislist = glob.glob('calibrated_final.ms')
+overwrite = True
+
+for vis in vislist:
+    tb.open(vis)
+    if "CORRECTED" in tb.colnames():
+        datacolumn="corrected"
+    else:
+        datacolumn="data"
+    tb.close()
+
+    msmd.open(vis)
+    for i in range(msmd.nobservations()):
+        outputvis = msmd.schedule(i)[1].split(" ")[1].replace("/","_").replace(":","_")+"_targets.ms"
+        if os.path.exists(outputvis):
+            if overwrite:
+                print(f"{outputvis} already exists, but overwrite=True, removing.")
+                os.system(f"rm -rf {outputvis}")
+            else:
+                print(f"{outputvis} already exists, skipping.")
+                continue
+
+        split(vis, outputvis=outputvis, observation=i, intent="*OBSERVE_TARGET*", \
+                spw=','.join(np.intersect1d(msmd.spwsforscan(msmd.scansforintent("*OBSERVE_TARGET*", obsid=0)[0], obsid=0), \
+                np.concatenate((msmd.tdmspws(),msmd.fdmspws()))).astype(str)), \
+                antenna=','.join(msmd.antennasforscan(msmd.scansforintent("*OBSERVE_TARGET*", obsid=i)[0], obsid=i).astype(str)), \
+                datacolumn=datacolumn)
+    msmd.close()


### PR DESCRIPTION
split_calibrated_final.py was originally designed to split a calibrated_final.ms file into the individual *_targets.ms files that were concatenated to make it. This PR is to expand the functionality so that it should work to split off the science targets and only the relevant science SPWs for any input dataset.

This is primarily achieved by intersecting the list of SPWs for the OBSERVE_TARGET scans with the lists of TDM and FDM spws, which only return the actual science SPWs. There is also a check for whether the CORRECTED_DATA column exists or not. An overwrite option has also been added.

For simplicity, I did not have the code check for all possible sets of files that could be provided (as that would be a large list...), but rather, the user can edit the glob command to specify the files that they want to be included.