### PR TITLE
Get multi-EB ephemeris selfcal working again

### DIFF
--- a/auto_selfcal.py
+++ b/auto_selfcal.py
@@ -266,8 +266,8 @@ for target in all_targets:
           for i in range(len(mosaic_field[band][vis][target]['field_ids'])):
               found = False
               for j in range(len(all_phasecenters)):
-                  distance = ((all_phasecenters[j]["m0"]["value"] - mosaic_field[band][vis][target]['phasecenters'][i]["m0"]["value"])**2 + \
-                          (all_phasecenters[j]["m1"]["value"] - mosaic_field[band][vis][target]['phasecenters'][i]["m1"]["value"])**2)**0.5
+                  distance = ((all_phasecenters[j][0] - mosaic_field[band][vis][target]['phasecenters'][i][0])**2 + \
+                          (all_phasecenters[j][1] - mosaic_field[band][vis][target]['phasecenters'][i][1])**2)**0.5
 
                   if distance < 4.84814e-6:
                       selfcal_library[target][band]['sub-fields-fid_map'][vis][j] = mosaic_field[band][vis][target]['field_ids'][i]
@@ -294,8 +294,19 @@ for target in all_targets:
               selfcal_library[target][band][fid][vis] = {}
 
 import json
+
+class NpEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.floating):
+            return float(obj)
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)
+
 if debug:
-    print(json.dumps(selfcal_library, indent=4))
+    print(json.dumps(selfcal_library, indent=4, cls=NpEncoder))
 ##
 ## finds solints, starting with inf, ending with int, and tries to align
 ## solints with number of integrations
@@ -440,16 +451,6 @@ for target in all_targets:
        selfcal_library[target][band][fid]['75thpct_uv']=band_properties[vislist[0]][band]['75thpct_uv']
        selfcal_library[target][band][fid]['LAS']=band_properties[vislist[0]][band]['LAS']
 
-
-class NpEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.integer):
-            return int(obj)
-        if isinstance(obj, np.floating):
-            return float(obj)
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        return json.JSONEncoder.default(self, obj)
 
 ##
 ## 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -206,9 +206,9 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                 if telescope=='ACA':
                    fov=108.0*100.0e9/band_properties[vis[0]][band]['meanfreq']*1.5*0.5
 
-                center = mosaic_field_phasecenters[field_id]
+                center = np.copy(mosaic_field_phasecenters[field_id])
                 if phasecenter == 'TRACKFIELD':
-                    center += imhead(imagename+".image.tt0")['refval']
+                    center += imhead(imagename+".image.tt0")['refval'][0:2]
 
                 region = 'circle[[{0:f}rad, {1:f}rad], {2:f}arcsec]'.format(center[0], center[1], fov)
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -206,8 +206,11 @@ def tclean_wrapper(vis, imagename, band_properties,band,telescope='undefined',sc
                 if telescope=='ACA':
                    fov=108.0*100.0e9/band_properties[vis[0]][band]['meanfreq']*1.5*0.5
 
-                region = 'circle[[{0:f}rad, {1:f}rad], {2:f}arcsec]'.format(mosaic_field_phasecenters[field_id]['m0']['value'], \
-                        mosaic_field_phasecenters[field_id]['m1']['value'], fov)
+                center = mosaic_field_phasecenters[field_id]
+                if phasecenter == 'TRACKFIELD':
+                    center += imhead(imagename+".image.tt0")['refval']
+
+                region = 'circle[[{0:f}rad, {1:f}rad], {2:f}arcsec]'.format(center[0], center[1], fov)
 
                 for ext in [".image.tt0", ".mask", ".residual.tt0", ".psf.tt0",".pb.tt0"]:
                     target = sanitize_string(field)
@@ -555,7 +558,13 @@ def fetch_scan_times_band_aware(vislist,targets,band_properties,band):
 
          mosaic_field[vis][target]['field_ids']=msmd.fieldsforscans(scansdict[vis][target]).tolist()
          mosaic_field[vis][target]['field_ids']=list(set(mosaic_field[vis][target]['field_ids']))
-         mosaic_field[vis][target]['phasecenters'] = [msmd.phasecenter(fid) for fid in mosaic_field[vis][target]['field_ids']]
+
+         mosaic_field[vis][target]['phasecenters'] = []
+         for fid in mosaic_field[vis][target]['field_ids']:
+             tb.open(vis+'/FIELD')
+             mosaic_field[vis][target]['phasecenters'].append(tb.getcol("PHASE_DIR")[:,0,fid])
+             tb.close()
+
          if len(mosaic_field[vis][target]['field_ids']) > 1:
             mosaic_field[vis][target]['mosaic']=True
          scantimes=np.array([])


### PR DESCRIPTION
When we started tracking sub-fields for mosaic selfcal, this broke ephemeris selfcal for multi-EB datasets because the sub-fields were identified based on phasecenter, and for an ephemeris target, the phase center is constantly changing. This was ok for a single EB dataset because it just used the phasecenter at the start of an observation, but for multi-EB datasets, this led to each EB having a different sub-field, which then caused problems down the line.

This PR gets selfcal working for multi-EB ephemeris targets again by pulling the phasecenter for each field from the FIELD table, specifically the PHASE_DIR column. For regular targets, this is just the RA/Dec phasecenter, but for ephemeris targets, this value is the offset from the ephemeris, and is therefore constant for all EBs. To make this work with mosaics, then, tclean_wrapper needs to grab the image center from the image header, and add the offsets to get the sub-fields.

I have tested this on both a mosaic ephemeris and regular ephemeris dataset and it is now working well for both.