### PR TITLE
Better handle cases where spws are flagged a priori

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -3087,6 +3087,13 @@ def get_flagged_solns_per_spw(spwlist,gaintable,extendpol=False):
          nunflagged = [tb.calc('[select from '+gaintable+' where SPECTRAL_WINDOW_ID=='+\
                  spwlist[i]+' giving  [nfalse(FLAG)]]')['0'].sum() for i in \
                  range(len(spwlist))]
+
+     nflags = np.array(nflags)
+     nunflagged = np.array(nunflagged)
+
+     nodata = np.where(nflags + nunflagged == 0)
+     nflags[nodata] = (nflags + nunflagged).max()
+
      os.system('rm -rf tempgaintable.g')
      fracflagged=np.array(nflags)/(np.array(nflags)+np.array(nunflagged))
      # Calculate a score based on those two.


### PR DESCRIPTION
I uncovered an issue where an entire spw is flagged a priori. Since there's no data, gaincal excludes the spw from the gain table. So when we collect flagging stats from the gain table for that spw, we get nflags = 0 and nunflagged = 0, and then the fraction flagged is a nan. Since we haven't built in nan-math, this leads to this spw actally being selected as the spw to map all other spws to in the spwmap case, which is obviously not right.

The solution here is search for cases where nflags == 0 and nunflagged == 0, and in those cases, set nflags to be the maximum value of (nflags + nunflagged), i.e. the total number of solutions, across all antennas. Then it shows up properly as 100% flagged in the stats.

I don't love the solution, mostly because it's perhaps not necessarily guaranteed that (nflags + nunflagged) is the same for all spws (even though it probably should be), but I think by taking the max, we should be ok even if it is not. But if you have any thoughts about a better way to achieve the same effect, happy to take suggestions!