### PR TITLE
add support for new cont.dat format

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1397,7 +1397,14 @@ def parse_contdotdat(contdotdat_file,target):
                continue
         if desiredTarget==True:
            if 'SpectralWindow' in line:
-              spw = int(line.split()[-1])
+              #code to adapt to new cont.dat format
+              splitline=line.split()
+              if len(splitline)==3:
+                 spw = int(splitline[-2])
+                 spwname=splitline[-1]
+              else:
+                 spw = int(splitline[-1])
+                 spwname=''
               contdotdat[spw] = []
            else:
               contdotdat[spw] += [line.split()[0].split("G")[0].split("~")]


### PR DESCRIPTION
The cont.dat format changed with the release of PL2024 to have extra fields denoting the spectral window name, in addition to the numerical ID. For example,

Field: AS_205A

SpectralWindow: 16 X84382813#ALMA_RB_08#BB_1#SW-01#FULL_RES
492.0185774166~492.0222417696GHz LSRK
492.0290818952~492.1351038420GHz LSRK
492.1686937445~492.2220711532GHz LSRK
492.2275676827~492.2335527926GHz LSRK

SpectralWindow: 18 X84382813#ALMA_RB_08#BB_2#SW-01#FULL_RES
489.6088855201~489.6121834297GHz LSRK
489.6184128145~489.7370154152GHz LSRK
489.7648644296~489.8063936616GHz LSRK
489.8238603680~489.8250818160GHz LSRK

SpectralWindow: 20 X84382813#ALMA_RB_08#BB_3#SW-01#FULL_RES
Flags: ALLCONT
476.7905610723~478.5729792599GHz LSRK

SpectralWindow: 22 X84382813#ALMA_RB_08#BB_4#SW-01#FULL_RES
478.6665921467~479.1588320627GHz LSRK
479.1891087242~480.3122751992GHz LSRK
480.3542718587~480.4802618372GHz LSRK

This PR updates the cont.dat parsing code to handle both types of cont.dat formats. Right now this simply looks for the number of elements in a string split by whitespace. If two elements, it's the old format, if three elements its the new format.

The format for specifying all continuum changed from simply ALL preceding the frequency ranges to 'Flags: ALLCONT', but that does not matter since the code currently just looks for 'ALL' withing a line and then skips to the next line.