### PR TITLE
Fix a collision between handling a-priori fully flagged spws and forcing low SNR spws to be spwmapped

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -3262,7 +3262,8 @@ def analyze_inf_EB_flagging(selfcal_library,band,spwlist,gaintable,vis,target,sp
    #if certain spws have more than max_flagged_ants_spwmap flagged solutions that the least flagged spws, set those to spwmap
    for i in range(len(spwlist)):
       if np.min(delta_nflags[i]) > max_flagged_ants_spwmap or \
-            solint_snr_per_spw['inf_EB'][str(selfcal_library['reverse_spw_map'][vis][int(spwlist[i])])] < minsnr_to_proceed:
+            solint_snr_per_spw['inf_EB'][str(selfcal_library['reverse_spw_map'][vis][int(spwlist[i])])] < minsnr_to_proceed or \
+            fracflagged[i] == 1.0:
          fallback='spwmap'
          spwmap[i]=True
          if total_bws[i] > min_spwmap_bw:


### PR DESCRIPTION
In reviewing our benchmark, I've discovered that there's a minor conflict between the code to handle a-priori fully flagged spws and the code to force low SNR spws to be spwmapped. In short, for a dataset with one wideband spw (0) that is a-priori fully flagged and 3 narrow spws (1, 2, 3), the combination of those two fixes causes us to end up with a spwmap of [0,3,3,3] (even though noting that all three of spws 1, 2, and 3 have low estimated SNRs. Because 0 gets mapped to itself, it prevents the code from doing the sensible thing of falling back to combinespw.

This fix is to force any fully flagged spw to be spwmapped, thus solving this problem. I think this is largely a sensible thing to do even if a spw is not *a-priori* fully flagged. (Though in most scenarios, this would happen naturally with the current heuristics, it is a bit of a corner case because not only is 0 entirely flagged, but 1, 2, and 3 end up almost entirely flagged and so delta_nflags doesn't end up very high for any of them).

One concern about this fix is that if 1, 2 or 3 happened to *also* be a continuum spw (or wide enough to have its own good solutions), this would end up forcing everything to be spwmapped. But until we start tracking a-priori flagged stats (in the spwcombine branch), I'm not sure there's a way to catch that case. In principle we could do that here since we do have the gaincal return dictionaries... but I don't know if it is worth the effort with the spwcombine branch coming soon.