### PR TITLE
Check only the spws that actually have data in them when checking whether all spws are mapped to the same one.

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -3302,7 +3302,7 @@ def analyze_inf_EB_flagging(selfcal_library,band,spwlist,gaintable,vis,target,sp
          fallback='combinespw'
 
    # If all of the spws map to the same spw, we might as well do a combinespw fallback.
-   if len(np.unique(applycal_spwmap)) == 1:
+   if len(np.unique(np.array(applycal_spwmap)[np.array(spwlist).astype(int)])) == 1:
        fallback = 'combinespw'
        applycal_spwmap = []
 


### PR DESCRIPTION
The analyze_inf_EB_flagging function checks whether all spws end up mapped to the same spw, and if so, decides to do the combinespw fallback. But for ALMA datasets this doesn't always work properly because there can be datasets where the relevant windows are, e.g. 17,19,21,23, and so the spwmap will be a 24 element list and only 4 of those elements will be mapped to the same spw.

This PR fixes this by extracting the spws that only the relevant spws are being mapped to, and checking whether those are all the same.