### PR TITLE
No need to re-store the clean threshold for mosaics if the full mosaic is remade due to failed fields

### DIFF
--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -368,7 +368,6 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                     ##
                     ## record self cal results/details for this solint
                     ##
-                    selfcal_library[vis][solint]['clean_threshold']=selfcal_library['nsigma'][iteration]*selfcal_library['RMS_NF_curr']
                     selfcal_library[vis][solint]['solmode']=selfcal_plan['solmode'][iteration]+''
                     ## Update RMS value if necessary
                     if selfcal_library[vis][solint]['RMS_post'] < selfcal_library['RMS_curr']:


### PR DESCRIPTION
Now that we are storing the clean threshold at the beginning of a solint, a la https://github.com/jjtobin/auto_selfcal/pull/66, we do not need to re-store it if a mosaic is remade because some of the sub-fields failed. (This was possibly wrong anyways for the reasons in that PR, i.e. RMS curr may have been updated compared with what was actually used for the tclean call.)