### PR TITLE
add fix to catch other flags present in cont.dat 

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1484,6 +1484,8 @@ def parse_contdotdat(contdotdat_file,target):
     for i, line in enumerate(lines):
         if 'ALL' in line:
            continue
+        if 'Flags:' in line:
+           continue
         if 'Field' in line:
             field=line.split()[-1]
             if field == target:


### PR DESCRIPTION
There can be extra information occasionally in the cont.dat that can break its parsing if we do not have code to ignore it.