### PR TITLE
fix rendering issue for mosaics when all solutions are dropped 

### DIFF
--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -2798,7 +2798,10 @@ def render_selfcal_solint_summary_table(htmlOut,sclib,target,band,selfcal_plan):
                      if quantity =='Flagged_Sols':
                         line+='<td>'+str(nflagged_sols)+'</td>\n'
                      if quantity =='Frac_Flagged':
-                        line+='<td>'+'{:0.3f}'.format(nflagged_sols/nsols)+'</td>\n'
+                        if nsols > 0:
+                           line+='<td>'+'{:0.3f}'.format(nflagged_sols/nsols)+'</td>\n'
+                        else:
+                           line+='<td>...</td>\n'
                   else:
                      line+='<td>-</td>\n'
                line+='</tr>\n    '


### PR DESCRIPTION
When all solutions get dropped, the a division by zero will result in the weblog which halts casa with an error. This fix first checks if nsols=0 and if so, it simply prints '...' instead of doing nflagged_sols/nsols.