### PR TITLE
PIPE-2517: Catch when a target has no scans between a set of calibrator scans and avoid adding an empty string to the list of scans to include.

### DIFF
--- a/gaincal_wrapper.py
+++ b/gaincal_wrapper.py
@@ -145,8 +145,10 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
                 msmd.open(vis)
                 include_scans = []
                 for iscan in range(scans.size-1):
-                    include_scans.append(",".join(np.intersect1d(msmd.scansforfield(target), \
-                            np.array(list(range(scans[iscan]+1,scans[iscan+1])))).astype(str)))
+                    scan_group = np.intersect1d(msmd.scansforfield(target), 
+                            np.array(list(range(scans[iscan]+1, scans[iscan+1])))).astype(str)
+                    if scan_group.size > 0:
+                        include_scans.append(",".join(scan_group))
                 msmd.close()
             elif guess_scan_combine:
                 msmd.open(vis)


### PR DESCRIPTION
In validation of the SRDP release of the pipeline, it was uncovered that in multi-target mosaics, if a target was not observed between successive visits to a gain calibrator, the include_scan list would add an empty string for that sequence when using the gain calibrator information available in the original MS file. That later led to an error when attempting to turn that empty string into an int. This PR fixes that by catching instances where no visits to the target are found for that gain calibrator interval and not adding anything to the include_scans list.

This is based on PIPE-2517.