### PR TITLE
Check both polarization for flags when dropping solutions from mosaic gaintables

### DIFF
--- a/gaincal_wrapper.py
+++ b/gaincal_wrapper.py
@@ -512,7 +512,7 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
                     if fid_n_solutions < 0.75 * max_n_solutions:
                         flags[:,:,fields == fid] = True
 
-        bad = np.where(flags[0,0,:])[0]
+        bad = np.where(np.any(flags, axis=0)[0])[0]
         tb.removerows(rownrs=bad)
         tb.flush()
         tb.close()


### PR DESCRIPTION
For mosaics, after the gaintable has been created, we drop any flagged solutions because flagged solutions can heavily impact adjacent fields, even if the adjacent fields have good calibration solutions themselves. The code to do this, however, was accidentally only checking one polarization for flags, so if the other polarization was flagged, the flag would remain. This PR is to extend the check to both polarizations.