### PR TITLE
add guess_scan_combine parameter to gaincal_wrapper calls and function definition

### DIFF
--- a/gaincal_wrapper.py
+++ b/gaincal_wrapper.py
@@ -14,7 +14,7 @@ except:
 def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, applymode, iteration, telescope, 
         gaincal_minsnr, gaincal_unflag_minsnr=5.0, minsnr_to_proceed=3.0, rerank_refants=False, unflag_only_lbants=False, unflag_only_lbants_onlyap=False, \
         calonly_max_flagged=0.0, second_iter_solmode="", unflag_fb_to_prev_solint=False, \
-        refantmode="flex", mode="selfcal", calibrators="", gaincalibrator_dict={}, allow_gain_interpolation=False):
+        refantmode="flex", mode="selfcal", calibrators="", gaincalibrator_dict={}, allow_gain_interpolation=False,guess_scan_combine=False):
 
     sani_target=sanitize_string(target)
     ##

--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -222,7 +222,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                         unflag_only_lbants=unflag_only_lbants, unflag_only_lbants_onlyap=unflag_only_lbants_onlyap, calonly_max_flagged=calonly_max_flagged, 
                         second_iter_solmode=second_iter_solmode, unflag_fb_to_prev_solint=unflag_fb_to_prev_solint, \
                         refantmode=refantmode, mode=mode, calibrators=calibrators, gaincalibrator_dict=gaincalibrator_dict, 
-                        allow_gain_interpolation=allow_gain_interpolation)
+                        allow_gain_interpolation=allow_gain_interpolation, guess_scan_combine=guess_scan_combine)
 
              # With gaincal done and bad fields removed from gain tables if necessary, check whether any fields should no longer be 
              # selfcal'd because they have too much interpolation.


### PR DESCRIPTION
This fixes a bug encountered when selfcal is run on mosaics without the original MSes to define where the gain calibrator scans are.