### PR TITLE
add else statement to set dividing factor to user specified parameter

### DIFF
--- a/prepare_selfcal.py
+++ b/prepare_selfcal.py
@@ -616,6 +616,8 @@ def set_clean_thresholds(selfcal_library, selfcal_plan, dividing_factor=-99.0, r
                dividing_factor_band=40.0
             elif (dividing_factor ==-99.0):
                dividing_factor_band=15.0
+            else:
+               dividing_factor_band=dividing_factor
 
             # restricts initial nsigma to be at least 5
             nsigma_init=np.max([selfcal_library[target][band]['SNR_NF_orig']/dividing_factor_band,5.0])


### PR DESCRIPTION
In testing a dataset that had really poor coherence and high S/N, to avoid cleaning the artifacts dividing_factor needed to be reduced significantly to avoid freezing these features into the data. However, specifying dividing factor lead to a crash because some changes to the if statements would result in dividing_factor_band to not be defined.