### PR TITLE
PL2025: Handle failure when calculating estimated SNR for a dataset where a sub-field is missing from the first EB of several (PIPE-2740)

### DIFF
--- a/run_selfcal.py
+++ b/run_selfcal.py
@@ -1280,7 +1280,7 @@ def run_selfcal(selfcal_library, target, band, solints, solint_snr, solint_snr_p
                             (selfcal_library[target][band][fid]['final_solint'] == 'inf_EB' and selfcal_library[target][band][fid]['inf_EB_SNR_decrease'])):
                        selfcal_library[target][band][fid]['SC_success']=False
                        selfcal_library[target][band][fid]['final_solint']='None'
-                       for vis in vislist:
+                       for vis in selfcal_library[target][band][fid]['vislist']:
                           selfcal_library[target][band][fid][vis]['inf_EB']['Pass']=False    #  remove the success from inf_EB
                           selfcal_library[target][band][fid][vis]['inf_EB']['Fail_Reason']+=' with no successful solints later'    #  remove the success from inf_EB
 

--- a/selfcal_helpers.py
+++ b/selfcal_helpers.py
@@ -1210,27 +1210,27 @@ def get_SNR_self_individual(vislist,selfcal_library,n_ant,solints,integration_ti
                selfcal_library['per_scan_SNR']=SNR/((n_ant-3)**0.5*(selfcal_library['Total_TOS']/selfcal_library['Median_scan_time'])**0.5)
                solint_snr[solint]=selfcal_library['per_scan_SNR']
                for spw in selfcal_library['spw_map']:
-                  vis = list(selfcal_library['spw_map'][spw].keys())[0]
+                  vis = np.intersect1d(list(selfcal_library['spw_map'][spw].keys()),selfcal_library['vislist'])[0]
                   true_spw = selfcal_library['spw_map'][spw][vis]
                   solint_snr_per_spw[solint][str(spw)]=SNR/((n_ant-3)**0.5*(selfcal_library['Total_TOS']/selfcal_library['Median_scan_time'])**0.5)*(selfcal_library[vis]['per_spw_stats'][true_spw]['effective_bandwidth']/selfcal_library[vis]['total_effective_bandwidth'])**0.5
          elif solint =='inf' or solint == 'inf_ap':
                selfcal_library['per_scan_SNR']=SNR/((n_ant-3)**0.5*(selfcal_library['Total_TOS']/(selfcal_library['Median_scan_time']/selfcal_library['Median_fields_per_scan']))**0.5)
                solint_snr[solint]=selfcal_library['per_scan_SNR']
                for spw in selfcal_library['spw_map']:
-                  vis = list(selfcal_library['spw_map'][spw].keys())[0]
+                  vis = np.intersect1d(list(selfcal_library['spw_map'][spw].keys()),selfcal_library['vislist'])[0]
                   true_spw = selfcal_library['spw_map'][spw][vis]
                   solint_snr_per_spw[solint][str(spw)]=SNR/((n_ant-3)**0.5*(selfcal_library['Total_TOS']/(selfcal_library['Median_scan_time']/selfcal_library['Median_fields_per_scan']))**0.5)*(selfcal_library[vis]['per_spw_stats'][true_spw]['effective_bandwidth']/selfcal_library[vis]['total_effective_bandwidth'])**0.5
          elif solint == 'int':
                solint_snr[solint]=SNR/((n_ant-3)**0.5*(selfcal_library['Total_TOS']/integration_time)**0.5)
                for spw in selfcal_library['spw_map']:
-                  vis = list(selfcal_library['spw_map'][spw].keys())[0]
+                  vis = np.intersect1d(list(selfcal_library['spw_map'][spw].keys()),selfcal_library['vislist'])[0]
                   true_spw = selfcal_library['spw_map'][spw][vis]
                   solint_snr_per_spw[solint][str(spw)]=SNR/((n_ant-3)**0.5*(selfcal_library['Total_TOS']/integration_time)**0.5)*(selfcal_library[vis]['per_spw_stats'][true_spw]['effective_bandwidth']/selfcal_library[vis]['total_effective_bandwidth'])**0.5
          else:
                solint_float=float(solint.replace('s','').replace('_ap',''))
                solint_snr[solint]=SNR/((n_ant-3)**0.5*(selfcal_library['Total_TOS']/solint_float)**0.5)
                for spw in selfcal_library['spw_map']:
-                  vis = list(selfcal_library['spw_map'][spw].keys())[0]
+                  vis = np.intersect1d(list(selfcal_library['spw_map'][spw].keys()),selfcal_library['vislist'])[0]
                   true_spw = selfcal_library['spw_map'][spw][vis]
                   solint_snr_per_spw[solint][str(spw)]=SNR/((n_ant-3)**0.5*(selfcal_library['Total_TOS']/solint_float)**0.5)*(selfcal_library[vis]['per_spw_stats'][true_spw]['effective_bandwidth']/selfcal_library[vis]['total_effective_bandwidth'])**0.5
       return solint_snr,solint_snr_per_spw
@@ -2727,7 +2727,7 @@ def render_spw_stats_summary_table(htmlOut,sclib,target,band):
                 line+='    <td>{:0.3f}</td>\n'.format(sclib[target][band]['per_spw_stats'][spw][key])
              if 'RMS' in key and key in spwkeys:
                 line+='    <td>{:0.3e} mJy/bm</td>\n'.format(sclib[target][band]['per_spw_stats'][spw][key]*1000.0)
-         vis = list(sclib[target][band]['spw_map'][spw].keys())[0]
+         vis = np.intersect1d(list(sclib[target][band]['spw_map'][spw].keys()), sclib[target][band]['vislist'])[0]
          if 'bandwidth' in key and key in sclib[target][band][vis]['per_spw_stats'][sclib[target][band]['spw_map'][spw][vis]].keys():
             line+='    <td>{:0.4f} GHz</td>\n'.format(sclib[target][band][vis]['per_spw_stats'][sclib[target][band]['spw_map'][spw][vis]][key])
          if key in sclib[target][band]['vislist'] and key in sclib[target][band]['spw_map'][spw]:


### PR DESCRIPTION
The get_SNR_self_individual function uses the spw_map to get the list of EBs, but the spw_map is created using the target as a whole. So, if a sub-field is missing from the first EB, when calculating the estimated SNR for that sub-field, the spw_map vislist will return an EB that does not have that field, and so when it tries to access information based on that EB, it fails. This fix takes the intersect of the sub-field vislist and the spw_map vislist to get the list of EBs that have both the sub-field and the spw.

As a note, it is in theory possible to have a multi-EB mosaic dataset where one EB is missing the sub-field and the other is missing the spw such that this intersect is empty. This PR does not handle this case, matching PL2025, but a more comprehensive fix will be coming to main soon. This is most likely to happen for VLA mosaics, but this branch does not have self-calibration of VLA mosaics (as a mosaic) implemented. It could also happen for ALMA datasets that have been modified.

@jjtobin - I'm running the test of this fix now. It worked on main, but need to test the clone onto the pl2025 branch.