### PR TITLE
Shorter inf_EB solution intervals possible

### DIFF
--- a/auto_selfcal/auto_selfcal.py
+++ b/auto_selfcal/auto_selfcal.py
@@ -58,6 +58,7 @@ def auto_selfcal(
         debug=False, 
         parallel=False,
         weblog=True,
+        max_solint=4500.0,
         **kwargs):
     """
     Main function to run the self-calibration pipeline.
@@ -224,6 +225,11 @@ def auto_selfcal(
     weblog : bool, optional
         If True, will create a weblog that provides information on how the 
         self-calibration process proceeded.
+    max_solint : float, optional
+        Preference for longest allowable solint for inf_EB, default avoids making
+        solints that are so long that long-timescale phase offset corrections
+        are not smeared out 
+        default : 4500.0
     **kwargs : dict, optional
         Additional keyword arguments to pass to the self-calibration 
         functions.
@@ -322,7 +328,7 @@ def auto_selfcal(
             target_selfcal_library, target_selfcal_plan, target_gaincalibrator_dict = prepare_selfcal([target], [band], vis_for_targets[target][band]['vislist'], 
                     spectral_average=spectral_average, sort_targets_and_EBs=sort_targets_and_EBs, scale_fov=scale_fov, inf_EB_gaincal_combine=inf_EB_gaincal_combine, 
                     inf_EB_gaintype=inf_EB_gaintype, apply_cal_mode_default=apply_cal_mode_default, do_amp_selfcal=do_amp_selfcal, 
-                    usermask=usermask, usermodel=usermodel,debug=debug)
+                    usermask=usermask, usermodel=usermodel,max_solint=max_solint,debug=debug)
 
             selfcal_library[target][band] = target_selfcal_library[target][band]
             selfcal_plan[target][band] = target_selfcal_plan[target][band]

--- a/auto_selfcal/gaincal_wrapper.py
+++ b/auto_selfcal/gaincal_wrapper.py
@@ -1,7 +1,7 @@
 import numpy as np
 from .selfcal_helpers import *
 
-def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, applymode, iteration, telescope, 
+def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, solint_interval, applymode, iteration, telescope, 
         gaincal_minsnr, gaincal_unflag_minsnr=5.0, minsnr_to_proceed=3.0, rerank_refants=False, unflag_only_lbants=False, unflag_only_lbants_onlyap=False, 
         calonly_max_flagged=0.0, second_iter_solmode="", unflag_fb_to_prev_solint=False, \
         refantmode="flex", mode="selfcal", calibrators="", gaincalibrator_dict={}, allow_gain_interpolation=False,spectral_solution_fraction=0.3,
@@ -285,7 +285,7 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
                       if mode != 'per_bb':      
                          gcdict=call_gaincal(vis=vis, caltable=gaintable_name, gaintype=selfcal_plan[vis]['solint_settings'][solint]['gaincal_gaintype'][mode], spw=spwselect,
                                 refant=selfcal_library[vis]['refant'], calmode=selfcal_plan['solmode'][iteration], solnorm=solnorm if not do_fallback_calonly else False,
-                                solint=solint.replace('_EB','').replace('_ap','').replace('scan_','').replace('_fb1','').replace('_fb2','').replace('_fb3',''),\
+                                solint=solint_interval.replace('_EB','').replace('_ap','').replace('scan_','').replace('_fb1','').replace('_fb2','').replace('_fb3',''),\
                                 minsnr=gaincal_minsnr if not do_fallback_calonly else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=gaincal_combine,\
                                 field=incl_targets,scan=incl_scans,gaintable=gaincal_preapply_gaintable,spwmap=gaincal_spwmap,uvrange=selfcal_library['uvrange'],\
                                 interp=gaincal_interpolate, solmode=gaincal_solmode, refantmode='flex',\
@@ -296,7 +296,7 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
                              spwselect_bb=selfcal_library[vis]['baseband'][baseband]['spwstring']
                              gcdict=call_gaincal(vis=vis, caltable=gaintable_name, gaintype=selfcal_plan[vis]['solint_settings'][solint]['gaincal_gaintype'][mode], spw=spwselect_bb,
                                   refant=selfcal_library[vis]['refant'], calmode=selfcal_plan['solmode'][iteration], solnorm=solnorm if not do_fallback_calonly else False,
-                                  solint=solint.replace('_EB','').replace('_ap','').replace('scan_','').replace('_fb1','').replace('_fb2','').replace('_fb3',''),\
+                                  solint=solint_interval.replace('_EB','').replace('_ap','').replace('scan_','').replace('_fb1','').replace('_fb2','').replace('_fb3',''),\
                                   minsnr=gaincal_minsnr if not do_fallback_calonly else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=gaincal_combine,\
                                   field=incl_targets,scan=incl_scans,gaintable=gaincal_preapply_gaintable,spwmap=gaincal_spwmap,uvrange=selfcal_library['uvrange'],\
                                   interp=gaincal_interpolate, solmode=gaincal_solmode, refantmode='flex',\
@@ -422,7 +422,7 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
                   if mode != 'per_bb':      
                      gcdict=call_gaincal(vis=vis, caltable=gaintable_name, gaintype=selfcal_plan[vis]['solint_settings'][solint]['gaincal_gaintype'][mode], spw=spwselect,
                             refant=selfcal_library[vis]['refant'], calmode=selfcal_plan['solmode'][iteration], solnorm=solnorm if not do_fallback_calonly else False,
-                            solint=solint.replace('_EB','').replace('_ap','').replace('scan_',''),\
+                            solint=solint_interval.replace('_EB','').replace('_ap','').replace('scan_',''),\
                             minsnr=gaincal_minsnr if not do_fallback_calonly else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=gaincal_combine,\
                             field=str(selfcal_library['sub-fields-fid_map'][vis][fid]),gaintable=gaincal_preapply_gaintable,spwmap=gaincal_spwmap,uvrange=selfcal_library['uvrange'],\
                             interp=gaincal_interpolate, solmode=gaincal_solmode, refantmode='flex',\
@@ -433,7 +433,7 @@ def gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, ap
                          spwselect_bb=selfcal_library[vis]['baseband'][baseband]['spwstring']
                          gcdict=call_gaincal(vis=vis, caltable=gaintable_name, gaintype=selfcal_plan[vis]['solint_settings'][solint]['gaincal_gaintype'][mode], spw=spwselect_bb,
                               refant=selfcal_library[vis]['refant'], calmode=selfcal_plan['solmode'][iteration], solnorm=solnorm if not do_fallback_calonly else False,
-                              solint=solint.replace('_EB','').replace('_ap','').replace('scan_',''),\
+                              solint=solint_interval.replace('_EB','').replace('_ap','').replace('scan_',''),\
                               minsnr=gaincal_minsnr if not do_fallback_calonly else max(gaincal_minsnr,gaincal_unflag_minsnr), minblperant=4,combine=gaincal_combine,\
                               field=str(selfcal_library['sub-fields-fid_map'][vis][fid]),gaintable=gaincal_preapply_gaintable,spwmap=gaincal_spwmap,uvrange=selfcal_library['uvrange'],\
                               interp=gaincal_interpolate, solmode=gaincal_solmode, refantmode='flex',\

--- a/auto_selfcal/prepare_selfcal.py
+++ b/auto_selfcal/prepare_selfcal.py
@@ -462,6 +462,7 @@ def prepare_selfcal(all_targets, bands, vislist,
                     scannfieldsdict[band],scanstartsdict[band],scanendsdict[band],integrationtimesdict[band],\
                     inf_EB_gaincal_combine,do_amp_selfcal=do_amp_selfcal,mosaic=selfcal_library[target][band]['obstype'] == 'mosaic', max_solint=max_solint)
              print(band,target,selfcal_plan[target][band]['solints'])
+             print(band,target,selfcal_plan[target][band]['solint_interval'])
              selfcal_plan[target][band]['applycal_mode']=[apply_cal_mode_default]*len(selfcal_plan[target][band]['solints'])
 
     ##

--- a/auto_selfcal/prepare_selfcal.py
+++ b/auto_selfcal/prepare_selfcal.py
@@ -11,6 +11,7 @@ def prepare_selfcal(all_targets, bands, vislist,
         do_amp_selfcal=True,
         usermask={},
         usermodel={},
+        max_solint=4500.0,
         debug=False):
 
     n_ants=get_n_ants(vislist)
@@ -457,9 +458,9 @@ def prepare_selfcal(all_targets, bands, vislist,
           selfcal_plan[target][band] = {}
           if band in selfcal_library[target]:
              selfcal_plan[target][band]['solints'],selfcal_plan[target][band]['integration_time'],selfcal_plan[target][band]['gaincal_combine'], \
-                    selfcal_plan[target][band]['solmode']=get_solints_simple(selfcal_library[target][band]['vislist'],scantimesdict[band],
+                    selfcal_plan[target][band]['solmode'],selfcal_plan[target][band]['solint_interval']=get_solints_simple(selfcal_library[target][band]['vislist'],scantimesdict[band],\
                     scannfieldsdict[band],scanstartsdict[band],scanendsdict[band],integrationtimesdict[band],\
-                    inf_EB_gaincal_combine,do_amp_selfcal=do_amp_selfcal,mosaic=selfcal_library[target][band]['obstype'] == 'mosaic')
+                    inf_EB_gaincal_combine,do_amp_selfcal=do_amp_selfcal,mosaic=selfcal_library[target][band]['obstype'] == 'mosaic', max_solint=max_solint)
              print(band,target,selfcal_plan[target][band]['solints'])
              selfcal_plan[target][band]['applycal_mode']=[apply_cal_mode_default]*len(selfcal_plan[target][band]['solints'])
 

--- a/auto_selfcal/run_selfcal.py
+++ b/auto_selfcal/run_selfcal.py
@@ -239,7 +239,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
          ## Apply gain solutions per MS, target, solint, and band
          ##
          for vis in vislist:
-            applycal_wrapper(vis, target, band, solint, solint_interval, selfcal_library, 
+            applycal_wrapper(vis, target, band, solint, selfcal_library, 
                     current=lambda f: f in selfcal_library['sub-fields-to-selfcal'],
                     final=lambda f: f not in selfcal_library['sub-fields-to-selfcal'] and selfcal_library[f]['SC_success'],
                     restore_flags='fb_selfcal_starting_flags_'+sani_target+'_'+band if mode == "cocal" else None)
@@ -350,7 +350,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
              field_by_field_success_dict = dict(zip(selfcal_library['sub-fields-to-selfcal'], field_by_field_success))
              print('****************Not all fields were successful, so re-applying and re-making _post image*************')
              for vis in vislist:
-                 applycal_wrapper(vis, target, band, solint, solint_interval, selfcal_library, 
+                 applycal_wrapper(vis, target, band, solint, selfcal_library, 
                          current=lambda f: f in field_by_field_success_dict and field_by_field_success_dict[f],
                          final=lambda f: (f not in field_by_field_success_dict or not field_by_field_success_dict[f]) and 
                              selfcal_library[f]['SC_success'],
@@ -511,7 +511,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
              if iteration > 0: # reapply only the previous gain tables, to get rid of solutions from this selfcal round
                 print('****************Reapplying previous solint solutions*************')
                 for vis in vislist:
-                   applycal_wrapper(vis, target, band, solint, solint_interval, selfcal_library, 
+                   applycal_wrapper(vis, target, band, solint, selfcal_library, 
                            final=lambda f: selfcal_library[f]['SC_success'],
                            restore_flags=("fb_" if mode == "cocal" else "")+'selfcal_starting_flags_'+sani_target+'_'+band)
              else:
@@ -660,7 +660,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                           selfcal_library[fid][vis]['inf_EB']['Fail_Reason']+=' with no successful solints later'    #  remove the success from inf_EB
 
              for vis in vislist:
-                 applycal_wrapper(vis, target, band, solint, solint_interval, selfcal_library, 
+                 applycal_wrapper(vis, target, band, solint, selfcal_library, 
                          final=lambda f: selfcal_library[f]['SC_success'],
                          clear=lambda f: not selfcal_library[f]['SC_success'], 
                          restore_flags=("fb_" if mode == "cocal" else "")+'selfcal_starting_flags_'+sani_target+'_'+band)

--- a/auto_selfcal/run_selfcal.py
+++ b/auto_selfcal/run_selfcal.py
@@ -70,8 +70,8 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
    print('Starting selfcal procedure on: '+target+' '+band)
    while iteration  < len(selfcal_plan['solints']):
 
-      print("Solving for solint="+selfcal_plan['solints'][iteration])
-
+      print("Solving for solint="+selfcal_plan['solints'][iteration]+' with interval '+selfcal_plan['solint_interval'][iteration])
+      
       # Set some cocal parameters.
       if selfcal_plan['solints'][iteration] in ["inf_EB_fb","inf_fb1"]:
           calculate_inf_EB_fb_anyways = True
@@ -113,6 +113,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
          break
       else:
          solint=selfcal_plan['solints'][iteration]
+         solint_interval=selfcal_plan['solint_interval'][iteration]
          if iteration == 0:
             print('Starting with solint: '+solint)
          else:
@@ -220,7 +221,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                        list(selfcal_library['sub-fields-fid_map'][vis].keys())).size == 0:
                     continue
 
-               gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, selfcal_plan['applycal_mode'][iteration], iteration, telescope, gaincal_minsnr, 
+               gaincal_wrapper(selfcal_library, selfcal_plan, target, band, vis, solint, solint_interval, selfcal_plan['applycal_mode'][iteration], iteration, telescope, gaincal_minsnr, 
                        gaincal_unflag_minsnr=gaincal_unflag_minsnr, minsnr_to_proceed=minsnr_to_proceed, rerank_refants=rerank_refants, \
                        unflag_only_lbants=unflag_only_lbants, unflag_only_lbants_onlyap=unflag_only_lbants_onlyap, calonly_max_flagged=calonly_max_flagged, 
                        second_iter_solmode=second_iter_solmode, unflag_fb_to_prev_solint=unflag_fb_to_prev_solint, \
@@ -238,7 +239,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
          ## Apply gain solutions per MS, target, solint, and band
          ##
          for vis in vislist:
-            applycal_wrapper(vis, target, band, solint, selfcal_library, 
+            applycal_wrapper(vis, target, band, solint, solint_interval, selfcal_library, 
                     current=lambda f: f in selfcal_library['sub-fields-to-selfcal'],
                     final=lambda f: f not in selfcal_library['sub-fields-to-selfcal'] and selfcal_library[f]['SC_success'],
                     restore_flags='fb_selfcal_starting_flags_'+sani_target+'_'+band if mode == "cocal" else None)
@@ -349,7 +350,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
              field_by_field_success_dict = dict(zip(selfcal_library['sub-fields-to-selfcal'], field_by_field_success))
              print('****************Not all fields were successful, so re-applying and re-making _post image*************')
              for vis in vislist:
-                 applycal_wrapper(vis, target, band, solint, selfcal_library, 
+                 applycal_wrapper(vis, target, band, solint, solint_interval, selfcal_library, 
                          current=lambda f: f in field_by_field_success_dict and field_by_field_success_dict[f],
                          final=lambda f: (f not in field_by_field_success_dict or not field_by_field_success_dict[f]) and 
                              selfcal_library[f]['SC_success'],
@@ -510,7 +511,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
              if iteration > 0: # reapply only the previous gain tables, to get rid of solutions from this selfcal round
                 print('****************Reapplying previous solint solutions*************')
                 for vis in vislist:
-                   applycal_wrapper(vis, target, band, solint, selfcal_library, 
+                   applycal_wrapper(vis, target, band, solint, solint_interval, selfcal_library, 
                            final=lambda f: selfcal_library[f]['SC_success'],
                            restore_flags=("fb_" if mode == "cocal" else "")+'selfcal_starting_flags_'+sani_target+'_'+band)
              else:
@@ -659,7 +660,7 @@ def run_selfcal(selfcal_library, selfcal_plan, target, band, telescope, n_ants, 
                           selfcal_library[fid][vis]['inf_EB']['Fail_Reason']+=' with no successful solints later'    #  remove the success from inf_EB
 
              for vis in vislist:
-                 applycal_wrapper(vis, target, band, solint, selfcal_library, 
+                 applycal_wrapper(vis, target, band, solint, solint_interval, selfcal_library, 
                          final=lambda f: selfcal_library[f]['SC_success'],
                          clear=lambda f: not selfcal_library[f]['SC_success'], 
                          restore_flags=("fb_" if mode == "cocal" else "")+'selfcal_starting_flags_'+sani_target+'_'+band)

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -1254,7 +1254,7 @@ def get_SNR_self(selfcal_library,selfcal_plan,n_ant,inf_EB_gaincal_combine,inf_E
           selfcal_plan[target][band][fid] = {}
           selfcal_plan[target][band][fid]['solint_snr_per_field'], selfcal_plan[target][band][fid]['solint_snr_per_field_per_spw'], selfcal_plan[target][band][fid]['solint_snr_per_field_per_bb'] = \
                   get_SNR_self_individual(selfcal_library[target][band]['vislist'], selfcal_library[target][band][fid], n_ant, 
-                  selfcal_plan[target][band]['solints'], selfcal_plan[target][band]['integration_time'], inf_EB_gaincal_combine, 
+                  selfcal_plan[target][band]['solints'], selfcal_plan[target][band]['solint_interval'], selfcal_plan[target][band]['integration_time'], inf_EB_gaincal_combine, 
                   inf_EB_gaintype)
 
           print('Estimated SNR per solint:')

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -1299,8 +1299,8 @@ def get_SNR_self_individual(vislist,selfcal_library,n_ant,solints,solints_interv
             SNR_self_EB_spw={}
             SNR_self_EB_bb={}
             for i in range(len(selfcal_library['vislist'])):
-               if solint_interval[s] != 'inf':
-                   solint_float=float(solint_interval[s].replace('s',''))
+               if solints_interval[s] != 'inf':
+                   solint_float=float(solints_interval[s].replace('s',''))
                    #use length of EB for S/N if inf_EB solint
                    inf_EB_tint=solint_float
                    if solint_float > selfcal_library[selfcal_library['vislist'][i]]['TOS']:


### PR DESCRIPTION
To account for the possibility of EBs being longer than ~2 hours, we have introduced the ability to limit the length of the inf_EB solint. This solint will still be called inf_EB, but the actual solution interval used will be defined based on a settable parameter _max_solint_. However, solutions will not automatically split once _max_solint_ is reached, rather they math works out such that inf_EB starts to be subdivided once the length of an EB (start of first scan - end of last scan for a target) is ~1.6*max_solint. This change will prevent the benefits of the very long solution interval from being smeared out on very long EBs that can still sometimes run on the VLA.