### PR TITLE
Improve functionality of auto_selfcal pip-installed into monolithic CASA

### DIFF
--- a/auto_selfcal/__init__.py
+++ b/auto_selfcal/__init__.py
@@ -11,6 +11,7 @@ try:
             try:
                 import pytest
                 os.system(f'cd {casa_path}/bin; ln -s casa pytest')
+                os.system(f'{casa_path}/bin/pip3 install --upgrade pytest')
             except:
                 pass
 except:

--- a/auto_selfcal/__init__.py
+++ b/auto_selfcal/__init__.py
@@ -1,3 +1,21 @@
+try:
+    import os
+    if os.getenv("CASAPATH") is not None:
+        import casampi.private.start_mpi
+
+    def setup_monolithic_CASA(pytest=False):
+        casa_path = os.getenv("CASAPATH").split(" ")[0]
+        os.system(f'cd {casa_path}/bin; ln -s casa auto_selfcal')
+
+        if pytest:
+            try:
+                import pytest
+                os.system(f'cd {casa_path}/bin; ln -s casa pytest')
+            except:
+                pass
+except:
+    pass
+
 from .auto_selfcal import auto_selfcal
 from .regenerate_weblog import regenerate_weblog
 from .split_calibrated_final import split_calibrated_final

--- a/auto_selfcal/tests/test_auto_selfcal.py
+++ b/auto_selfcal/tests/test_auto_selfcal.py
@@ -50,7 +50,11 @@ def test_benchmark(tmp_path, dataset):
     os.system(f"cp -r /lustre/cv/projects/SRDP/selfcal-prototyping/datasets/{dataset}/cont.dat .")
     os.system(f"cp -r /lustre/cv/projects/SRDP/selfcal-prototyping/datasets/{dataset}/selfcal_library_reference.pickle .")
 
-    ex = submitit.SlurmExecutor(folder=".", python=f"OMP_NUM_THREADS=1 xvfb-run -d mpirun -n 8 {sys.executable}")
+    if os.getenv("CASAPATH") == None:
+        ex = submitit.SlurmExecutor(folder=".", python=f"OMP_NUM_THREADS=1 xvfb-run -d mpirun -n 8 {sys.executable}")
+    else:
+        casa_path = os.getenv("CASAPATH").split(" ")[0]
+        ex = submitit.SlurmExecutor(folder=".", python=f"xvfb-run -d {casa_path}/bin/mpicasa -n 8 {casa_path}/bin/python3")
     ex.update_parameters(partition="batch2", nodes=1, ntasks_per_node=8, cpus_per_task=1, use_srun=False, time=10080, \
             mem="128gb", job_name=dataset)
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Installing into Monolithic CASA
 -------------------------------
 
-Formal installation into monolithic CASA is not required, as we provide script versions of the main functionality of this package (see :ref:`Running in Monolithic CASA` for further details on usage). To use auto_selfcal in this way, simply download stable versions of the code on our `GitHub releases page <https://github.com/jjtobin/auto_selfcal/releases>`_. For the latest developmental version, run
+Formal installation into monolithic CASA is not required, as we provide script versions of the main functionality of this package (see :ref:`Running the scripted version in Monolithic CASA` for further details on usage). To use auto_selfcal in this way, simply download stable versions of the code on our `GitHub releases page <https://github.com/jjtobin/auto_selfcal/releases>`_. For the latest developmental version, run
 
 .. code-block:: bash
 
@@ -12,15 +12,23 @@ Formal installation into monolithic CASA is not required, as we provide script v
 
 in a terminal. The core auto_selfcal scripts now exist in the ``auto_selfcal/bin`` directory.
 
-If you do, however, want to install into monolithic CASA, see below, under :ref:`Installing with pip`. If you opt for this route, be sure to use the ``pip`` installed with your monolithic CASA distribution (i.e. ``</path/to/monolithic/CASA>/bin/pip3``).
+It is, however, possible to pip install into monolithic CASA. If you opt for this route, be sure to use the ``pip`` installed with your monolithic CASA distribution:
+
+.. code-block:: bash
+    
+    </path/to/monolithic/CASA>/bin/pip3 install auto-selfcal
+
 With that done, you can also run the following command to properly set up the auto_selfcal command line tool:
 
 .. code-block:: bash
 
     </path/to/monolithic/CASA/>/bin/casa -c "import auto_selfcal; auto_selfcal.setup_monolithic_CASA()"
 
+Installing into Modular CASA
+----------------------------
+
 Installing with pip
--------------------
+^^^^^^^^^^^^^^^^^^^
 
 auto_selfcal can be installed into any Python environment using the pip package manager:
 
@@ -39,7 +47,7 @@ To install auto_selfcal with support for casampi:
 A note: casampi can be quite particular about versions of mpi4py and other libraries. If you are having trouble, check the included environment.yaml file, which should document a configuration that works for casa 6.6.5 (and can be used to directly create a working environment within the Anaconda package manager, see below).
 
 Installing with conda
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 To create an Anaconda environment into which auto_selfcal can be installed, we provide an Anaconda environment file that is capable of reproducing the necessary environment. To create an environment from this file, run:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,12 @@ Formal installation into monolithic CASA is not required, as we provide script v
 
 in a terminal. The core auto_selfcal scripts now exist in the ``auto_selfcal/bin`` directory.
 
-If you do, however, want to install into monolithic CASA, see below, under :ref:`Installing with pip`. If you opt for this route, be sure to use the ``pip`` installed with your monolithic CASA distribution (i.e. ``</path/to/monolithic/CASA>/bin/pip``).
+If you do, however, want to install into monolithic CASA, see below, under :ref:`Installing with pip`. If you opt for this route, be sure to use the ``pip`` installed with your monolithic CASA distribution (i.e. ``</path/to/monolithic/CASA>/bin/pip3``).
+With that done, you can also run the following command to properly set up the auto_selfcal command line tool:
+
+.. code-block:: bash
+
+    </path/to/monolithic/CASA/>/bin/casa -c "import auto_selfcal; auto_selfcal.setup_monolithic_CASA()"
 
 Installing with pip
 -------------------

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -32,6 +32,23 @@ We also provide a tool to do continuum subtraction of the original MS files usin
 
 Note that with these scripts there is no support for command line arguments; to change these options, edit the bin/\*.py files directly. For details about the available parameters for each of these functions, see our :ref:`Top Level API`.
 
+Running when pip-installed into Monolithic CASA
+-----------------------------------------------
+
+If you pip install auto_selfcal into Monolithic CASA and properly setup the symbolic links (see :ref:`Installing into Monolithic CASA`) then the auto_selfcal command line tool should be available:
+
+.. code-block:: bash
+
+    </path/to/CASA>/bin/auto_selfcal --<command line option> <argument> ...
+
+or with mpicasa:
+
+.. code-block:: bash
+
+    </path/to/CASA>/bin/mpicasa -n <N> auto_selfcal --<command line option> <argument> ...
+
+Alternatively, auto_selfcal can be imported into an interactive CASA session as with any Python package. For further details on using the command line tool or Python interface, see below.
+
 Running in Modular CASA
 -----------------------
 

--- a/docs/running.rst
+++ b/docs/running.rst
@@ -1,10 +1,10 @@
 Running auto_selfcal
 ====================
 
-auto_selfcal can be run in two different modes, depending on whether you are using a modular CASA environment or a monolithic CASA distribution:
+auto_selfcal can be run in multiple ways, depending on whether you are using a modular CASA environment or a monolithic CASA distribution, and whether the code was pip-installed or you are using the scripted version:
 
-Running in Monolithic CASA
---------------------------
+Running the scripted version in Monolithic CASA
+-----------------------------------------------
 
 Although the structure is a little different, support remains for running auto_selfcal in a manner similar to versions 1.X within a monolithic CASA distribution. To do so, follow the instructions for :ref:`Installing into Monolithic CASA` and run:
 
@@ -45,9 +45,33 @@ or with mpicasa:
 
 .. code-block:: bash
 
-    </path/to/CASA>/bin/mpicasa -n <N> auto_selfcal --<command line option> <argument> ...
+    </path/to/CASA>/bin/mpicasa -n <N> </path/to/CASA>/bin/auto_selfcal --<command line option> <argument> ...
 
-Alternatively, auto_selfcal can be imported into an interactive CASA session as with any Python package. For further details on using the command line tool or Python interface, see below.
+For the same examples as above,
+
+.. code-block:: bash
+
+    </path/to/CASA>/bin/mpicasa -n 5 </path/to/CASA>/bin/auto_selfcal --action run
+    </path/to/CASA>/bin/auto_selfcal --action apply
+    </path/to/CASA>/bin/auto_selfcal --action contsub
+
+Alternatively, auto_selfcal can be imported into an interactive CASA session as with any Python package:
+
+.. code-block:: python
+
+    from auto_selfcal import auto_selfcal, applycal_to_orig_MSes, uvcontsub_orig_MSes
+
+    auto_selfcal(vislist=<list of MSes>)
+    applycal_to_orig_MSes()
+    uvcontsub_orig_MSes()
+
+For a full list of command line options, run:
+
+.. code-block:: bash
+
+    </path/to/CASA>/bin/auto_selfcal --help
+
+or see the API documentation for the :meth:`auto_selfcal<auto_selfcal.auto_selfcal>` function.
 
 Running in Modular CASA
 -----------------------

--- a/docs/weblog.rst
+++ b/docs/weblog.rst
@@ -24,7 +24,7 @@ If a weblog was not generated at the time that auto_selfcal was run, e.g. ``webl
 
     casa -c <path/to/auto_selfcal>/bin/regenerate_weblog.py
 
-In modular CASA, this can be done either via the command line tool
+In modular CASA or monolithic CASA with auto_selfcal pip-installed, this can be done either via the command line tool
 
 .. code-block:: bash
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mpi = ["casampi","mpi4py<4.0.0"]
-test = ["pytest","pytest-xdist","submitit"]
+test = ["pytest","pytest-cov","pytest-xdist","submitit"]
 docs = ["sphinx","sphinx-automodapi","sphinx_book_theme","numpydoc"]
 
 [project.urls]


### PR DESCRIPTION
This PR is to improve the ability to use auto_selfcal when pip-installed into monolithic CASA. This includes, in particular:

- The ability to install the auto_selfcal command-line tool into the monolithic CASA bin
- The above auto_selfcal command-line tool can be used with mpicasa for parallel processing
- Updated docs to reflect these new/improved capabilities.

@jjtobin, since this includes a documentation update, we should hold off on merging until shortly before our next release so that the docs reflect the capabilities of pip-installed auto_selfcal. Alternatively, if we set readthedocs to make the default 'stable', then I think we could also merge and the updates would only show up on 'latest'. But we would lose the fixes that I made to the docs after the release, so that may not be ideal.

I also want to run the doc changes by you to get your feedback.