### PR TITLE
PIPE-2937: Use in-memory CASA operations for estimate_SNR and estimate_near_field_SNR

### DIFF
--- a/auto_selfcal/casa_tools.py
+++ b/auto_selfcal/casa_tools.py
@@ -1,0 +1,15 @@
+from casatools import image as iatool
+
+class ImageReader:
+    def __init__(self, filename):
+        self.filename = filename
+
+    def __enter__(self):
+        self.ia = iatool()
+        self.ia.open(self.filename)
+
+        return self.ia
+    
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.ia:
+            self.ia.close()

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -2149,15 +2149,7 @@ def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library
    fov=fov*scale_fov
 
    if mosaic:
-       fieldid=selfcal_library[target][band]['sub-fields-phasecenters'].keys()
-
-       ra_phasecenter_arr=np.zeros(len(fieldid))
-       dec_phasecenter_arr=np.zeros(len(fieldid))
-
-       for k, key in enumerate(fieldid):
-          ra_phasecenter_arr[i]=selfcal_library[target][band]['sub-fields-phasecenters'][key][0]
-          dec_phasecenter_arr[i]=selfcal_library[target][band]['sub-fields-phasecenters'][key][1]
-
+       ra_phasecenter_arr, dec_phasecenter_arr = get_phasecenter_arrays(selfcal_library[target][band])
        median_dec=np.median(dec_phasecenter_arr)
        mosaic_size_x=(ra_phasecenter_arr.max() - ra_phasecenter_arr.min()) * 180./np.pi * 3600. *np.cos(median_dec)
        mosaic_size_y=(dec_phasecenter_arr.max() - dec_phasecenter_arr.min()) * 180./np.pi * 3600.
@@ -3073,16 +3065,8 @@ def check_mosaic(vislist,target):
       mosaic=False
    return mosaic
 
-def get_phasecenter(vis,selfcal_library,field,telescope):
-   fieldid=selfcal_library[target][band]['sub-fields-phasecenters'].keys()
-
-   ra_phasecenter_arr=np.zeros(len(fieldid))
-   dec_phasecenter_arr=np.zeros(len(fieldid))
-
-   for k, key in enumerate(fieldid):
-      ra_phasecenter_arr[i]=selfcal_library[target][band]['sub-fields-phasecenters'][key][0]
-      dec_phasecenter_arr[i]=selfcal_library[target][band]['sub-fields-phasecenters'][key][1]
-
+def get_phasecenter(vis,selfcal_library,target,telescope):
+   ra_phasecenter_arr, dec_phasecenter_arr = get_phasecenter_arrays(selfcal_library)
    #RA center = Min + delta ra
    ra_phasecenter=np.min(ra_phasecenter_arr)+(np.max(ra_phasecenter_arr)-np.min(ra_phasecenter_arr))/2.0
    dphi_dec=np.abs((np.max(dec_phasecenter_arr)-np.min(dec_phasecenter_arr))/2.0)
@@ -3090,6 +3074,18 @@ def get_phasecenter(vis,selfcal_library,field,telescope):
 
    phasecenter_string='ICRS {:0.8f}rad {:0.8f}rad '.format(ra_phasecenter,dec_phasecenter)
    return phasecenter_string
+
+def get_phasecenter_arrays(selfcal_library):
+   fieldid=selfcal_library['sub-fields-phasecenters'].keys()
+   ra_phasecenter_arr=np.zeros(len(fieldid))
+   dec_phasecenter_arr=np.zeros(len(fieldid))
+
+   for k, key in enumerate(fieldid):
+      ra_phasecenter_arr[k]=selfcal_library['sub-fields-phasecenters'][key][0]
+      dec_phasecenter_arr[k]=selfcal_library['sub-fields-phasecenters'][key][1]
+
+   return ra_phasecenter_arr, dec_phasecenter_arr
+
 
 def get_flagged_solns_per_spw(spwlist,gaintable,extendpol=False):
      # Get the antenna names and offsets.

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -2174,6 +2174,10 @@ def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library
        median_dec=np.median(dec_phasecenter_arr)
        mosaic_size_x=(ra_phasecenter_arr.max() - ra_phasecenter_arr.min()) * 180./np.pi * 3600. *np.cos(median_dec)
        mosaic_size_y=(dec_phasecenter_arr.max() - dec_phasecenter_arr.min()) * 180./np.pi * 3600.
+       def check_even(number):
+           if number % 2 != 0:  #even number will not have a remainder
+               number += 1     
+           return number
 
        fov_x = fov+mosaic_size_x
        fov_y = fov+mosaic_size_y
@@ -2181,10 +2185,13 @@ def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library
        buffer_pix=int(np.ceil(approx_npixels/10.0))
        npixels_x = int(np.ceil(fov_x/cell / buffer_pix)) * buffer_pix + buffer_pix
        npixels_y = int(np.ceil(fov_y/cell / buffer_pix)) * buffer_pix + buffer_pix
+       npixels_x = check_even(npixels_x)
+       npixels_y = check_even(npixels_y)
        npixels=[npixels_x,npixels_y]
    else:
        buffer_pix=int(np.ceil(fov/cell/10.0))
        pixels=int(np.ceil(fov/cell / buffer_pix)) * buffer_pix + buffer_pix
+       pixels=check_even(pixels)
        npixels=[pixels,pixels]
    if np.max(npixels) > 16384:
       if mosaic:

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -1512,7 +1512,7 @@ def estimate_near_field_SNR(
         if annulus_stats['min'][0] >= 0.99:
             print('Near field annulus is empty/fully masked.')
         else:
-            with casatools.ImageReader(imagename) as ia_im:
+            with casa_tools.ImageReader(imagename) as ia_im:
                 # Use LEL mask expression: valid where annulus mask image value < 0.5
                 mask_expr = f"'{ia_annulus.name()}' < 0.5"
                 try:

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -2066,7 +2066,7 @@ def largest_prime_factor(n):
             n //= i
     return n
 
-def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library,scale_fov=1.0,mosaic=False):
+def get_image_parameters_old(vislist,telescope,target,field_ids,band,selfcal_library,scale_fov=1.0,mosaic=False):
    cells=np.zeros(len(vislist))
    for i in range(len(vislist)):
       #im.open(vislist[i])
@@ -2118,7 +2118,7 @@ def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library
 
    return cellsize,[npixels,npixels],nterms,reffreq
 
-def get_image_parameters_new(vislist,telescope,target,field_ids,band,selfcal_library,scale_fov=1.0,mosaic=False):
+def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library,scale_fov=1.0,mosaic=False):
    cells=np.zeros(len(vislist))
    for i in range(len(vislist)):
       #im.open(vislist[i])
@@ -3075,15 +3075,11 @@ def check_mosaic(vislist,target):
 
 def get_phasecenter(vis,selfcal_library,field,telescope):
    msmd.open(vis)
-   if telescope == 'ALMA' or telescope == 'ACA': # put in to reproduce benchmark; actually incorrect since phantom fields will impact defined phase center
-       fieldid=msmd.fieldsforname(field) # only works for ALMA mosaics
-   else:
-       # should be more general
-       fieldid=np.array([],dtype=int)
-       for fid in selfcal_library['sub-fields']:
-          if fid in selfcal_library['sub-fields-fid_map'][vis].keys():
-             field_id=selfcal_library['sub-fields-fid_map'][vis][fid]
-             fieldid=np.append(fieldid,np.array([field_id]))
+   fieldid=np.array([],dtype=int)
+   for fid in selfcal_library['sub-fields']:
+      if fid in selfcal_library['sub-fields-fid_map'][vis].keys():
+         field_id=selfcal_library['sub-fields-fid_map'][vis][fid]
+         fieldid=np.append(fieldid,np.array([field_id]))
 
    ra_phasecenter_arr=np.zeros(len(fieldid))
    dec_phasecenter_arr=np.zeros(len(fieldid))
@@ -3097,10 +3093,6 @@ def get_phasecenter(vis,selfcal_library,field,telescope):
    ra_phasecenter=np.min(ra_phasecenter_arr)+(np.max(ra_phasecenter_arr)-np.min(ra_phasecenter_arr))/2.0
    dphi_dec=np.abs((np.max(dec_phasecenter_arr)-np.min(dec_phasecenter_arr))/2.0)
    dec_phasecenter=np.max(dec_phasecenter_arr)-dphi_dec
-
-   #switch back to old method until after VLA mosaics
-   ra_phasecenter=np.median(ra_phasecenter_arr)
-   dec_phasecenter=np.median(dec_phasecenter_arr)
 
    phasecenter_string='ICRS {:0.8f}rad {:0.8f}rad '.format(ra_phasecenter,dec_phasecenter)
    return phasecenter_string

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -2119,6 +2119,10 @@ def get_image_parameters_old(vislist,telescope,target,field_ids,band,selfcal_lib
    return cellsize,[npixels,npixels],nterms,reffreq
 
 def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library,scale_fov=1.0,mosaic=False):
+   def check_even(number):
+       if number % 2 != 0:  #even number will not have a remainder
+           number += 1     
+       return number
    cells=np.zeros(len(vislist))
    for i in range(len(vislist)):
       #im.open(vislist[i])
@@ -2174,10 +2178,7 @@ def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library
        median_dec=np.median(dec_phasecenter_arr)
        mosaic_size_x=(ra_phasecenter_arr.max() - ra_phasecenter_arr.min()) * 180./np.pi * 3600. *np.cos(median_dec)
        mosaic_size_y=(dec_phasecenter_arr.max() - dec_phasecenter_arr.min()) * 180./np.pi * 3600.
-       def check_even(number):
-           if number % 2 != 0:  #even number will not have a remainder
-               number += 1     
-           return number
+
 
        fov_x = fov+mosaic_size_x
        fov_y = fov+mosaic_size_y

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -1213,169 +1213,340 @@ def checkmask(imagename):
    else:
       return True
 
-def estimate_SNR(imagename,maskname=None,verbose=True, mosaic_sub_field=False):
-    MADtoRMS =  1.4826
-    headerlist = imhead(imagename, mode = 'list')
-    beammajor = headerlist['beammajor']['value']
-    beamminor = headerlist['beamminor']['value']
-    beampa = headerlist['beampa']['value']
+def estimate_SNR(
+    imagename: str,
+    maskname: str | None = None,
+    verbose: bool = True,
+    mosaic_sub_field: bool = False,
+) -> tuple[float, float]:
+    """Estimate the Signal-to-Noise Ratio (SNR) of an image.
 
-    if mosaic_sub_field:
-        os.system("rm -rf temp.image")
-        immath(imagename=[imagename, imagename.replace(".image",".pb"), imagename.replace(".image",".mospb")], outfile="temp.image", \
-                expr="IM0*IM1/IM2")
-        image_stats= imstat(imagename = "temp.image")
-        os.system("rm -rf temp.image")
-    else:
-        image_stats= imstat(imagename = imagename)
+    This function calculates the SNR by determining the peak intensity (considering
+    mosaic PBs if necessary) and the RMS noise (excluding the signal region masked
+    by the clean mask). This refactored version avoids writing temporary files.
 
+    Args:
+        imagename: Path to the image file.
+        maskname: Optional path to a mask file. If None, derived from imagename.
+        verbose: Whether to log the results.
+        mosaic_sub_field: If True, apply primary beam correction logic for stats.
+
+    Returns:
+        tuple[float, float]: (SNR, RMS). Returns (-99.0, -99.0) on error.
+    """
+    mad_to_rms = 1.4826
+    snr, rms = np.float64(-99.0), np.float64(-99.0)
+
+    try:
+        # 1. Calculate Peak Intensity (Corrected for Mosaic PB if needed)
+
+        with casa_tools.ImageReader(imagename) as image:
+            bm = image.restoringbeam(polarization=0)
+            if mosaic_sub_field:
+                # Calculate corrected image stats in memory: image * pb / mospb
+                pb_path = imagename.replace('.image', '.pb')
+                mospb_path = imagename.replace('.image', '.mospb')
+                if not os.path.exists(pb_path) or not os.path.exists(mospb_path):
+                    raise FileNotFoundError(
+                        f'Required PB or MOSPB image not found for mosaic sub-field SNR calculation: {pb_path}, {mospb_path}'
+                    )
+
+                # Use LEL expression in a transient image
+                calc_expr = f"'{imagename}' * '{pb_path}' / '{mospb_path}'"
+
+                # imagecalc with outfile='' creates a transient image tool
+                # attached to a memory-resident image/expression
+                ia_mospb = image.imagecalc(outfile='', pixels=calc_expr)
+                try:
+                    # robust=False mimics the default imstat (classic algorithm)
+                    image_stats = ia_mospb.statistics(robust=False)
+                finally:
+                    ia_mospb.close()
+            else:
+                image_stats = image.statistics(robust=False)
+
+        peak_intensity = image_stats['max'][0]
+
+        beammajor = bm['major']['value']
+        beamminor = bm['minor']['value']
+        beampa = bm['positionangle']['value']
+
+        # 2. RMS Calculation
+        if maskname is None:
+            mask_image = imagename.replace('image', 'mask').replace('.tt0', '')
+        else:
+            mask_image = maskname
+
+        # Determine validity of the default/implied mask associated with the image
+        good_mask = False
+        if 'dirty' not in imagename:
+            try:
+                good_mask = checkmask(imagename)
+            except Exception:
+                good_mask = False
+
+        if os.path.exists(mask_image) and good_mask:
+            with casa_tools.ImageReader(imagename) as image:
+                # Use LEL expression to mask pixels where the user mask > 0.5 (signal)
+                # We calculate RMS on the noise (mask < 0.5)
+                # 'mask(imagename)' ensures we respect the original image's validity mask
+                mask_expr = f"'{mask_image}' < 0.5 && mask('{imagename}')"
+
+                try:
+                    # calculate robust statistics (MAD)
+                    mask0_stats = image.statistics(mask=mask_expr, robust=True, axes=[0, 1])
+                    if len(mask0_stats['medabsdevmed']) > 0:
+                        rms = mask0_stats['medabsdevmed'][0] * mad_to_rms
+                    else:
+                        rms = 0.0
+                except Exception:
+                    # Fallback if masking fails or expression is invalid
+                    rms = 0.0
+        else:
+            # Fallback to Chauvenet algorithm on the full image
+            with casa_tools.ImageReader(imagename) as image:
+                stats = image.statistics(algorithm='chauvenet')
+                rms = stats['rms'][0] if len(stats['rms']) > 0 else 0.0
+
+        if rms > 0.0:
+            snr = peak_intensity / rms
+        else:
+            snr = 0.0
+
+        if verbose:
+            LOG.info('Image name: %s', imagename)
+            LOG.info(
+                'Beam %.3f arcsec x %.3f arcsec (%.2f deg)',
+                beammajor,
+                beamminor,
+                beampa,
+            )
+            LOG.info('Peak intensity of source: %.2f mJy/beam', peak_intensity * 1000)
+            LOG.info('rms: %.2e mJy/beam', rms * 1000)
+            LOG.info('Peak SNR: %.2f', snr)
+
+    except Exception:
+        LOG.error('Error in estimate_SNR: %s', traceback.format_exc())
+        return np.float64(-99.0), np.float64(-99.0)
+
+    return snr, rms
+
+
+def estimate_near_field_SNR(
+    imagename: str,
+    las: float | None = None,
+    maskname: str | None = None,
+    verbose: bool = True,
+    mosaic_sub_field: bool = False,
+    save_near_field_mask: bool = True,
+) -> tuple[float, float]:
+    """Estimate the near-field SNR using in-memory CASA tool operations.
+
+    This function avoids writing temporary images to disk and minimizes large numpy array
+    loading by utilizing CASA tools for transient image operations.
+
+    Args:
+        imagename: Path to the image file.
+        las: Largest Angular Scale in arcseconds. Defaults to None.
+        maskname: Name of the mask to use. If None, derives from imagename.
+        verbose: If True, logs details about the calculation. Defaults to True.
+        mosaic_sub_field: Whether the image is a mosaic sub-field. Defaults to False.
+        save_near_field_mask: If True, saves the generated near-field mask to disk.
+            Defaults to True.
+
+    Returns:
+        A tuple containing:
+            - SNR: The estimated Signal-to-Noise Ratio. Returns -99.0 on failure.
+            - RMS: The estimated Root Mean Square noise. Returns -99.0 on failure.
+    """
     if maskname is None:
-       maskImage=imagename.replace('image','mask').replace('.tt0','')
+        mask_image = imagename.replace('image', 'mask').replace('.tt0', '')
     else:
-       maskImage=maskname
-    residualImage=imagename # change to .image JT 04-15-2024 .replace('image','residual')
-    os.system('rm -rf temp.mask temp.residual')
-    if os.path.exists(maskImage):
-       os.system('cp -r '+maskImage+ ' temp.mask')
-       maskImage='temp.mask'
-    os.system('cp -r '+residualImage+ ' temp.residual')   # leave this as .residual to avoid clashing with another temp.image
-    residualImage='temp.residual'
-    if 'dirty' not in imagename:
-       goodMask=checkmask(imagename)
-    else:
-       goodMask=False
-    if os.path.exists(maskImage) and goodMask:
-       ia.close()
-       ia.done()
-       ia.open(residualImage)
-       #ia.calcmask(maskImage+" <0.5"+"&& mask("+residualImage+")",name='madpbmask0')
-       ia.calcmask("'"+maskImage+"'"+" <0.5"+"&& mask("+residualImage+")",name='madpbmask0')
-       mask0Stats = ia.statistics(robust=True,axes=[0,1])
-       ia.maskhandler(op='set',name='madpbmask0')
-       rms = mask0Stats['medabsdevmed'][0] * MADtoRMS
-       residualMean = mask0Stats['median'][0]
-    else:
-       residual_stats=imstat(imagename=imagename,algorithm='chauvenet')
-       rms = residual_stats['rms'][0]
-    peak_intensity = image_stats['max'][0]
-    SNR = peak_intensity/rms
-    if verbose:
-           print("#%s" % imagename)
-           print("#Beam %.3f arcsec x %.3f arcsec (%.2f deg)" % (beammajor, beamminor, beampa))
-           print("#Peak intensity of source: %.2f mJy/beam" % (peak_intensity*1000,))
-           print("#rms: %.2e mJy/beam" % (rms*1000,))
-           print("#Peak SNR: %.2f" % (SNR,))
-    ia.close()
-    ia.done()
-    if mosaic_sub_field:
-        os.system("rm -rf temp.image")
-    os.system('rm -rf temp.mask temp.residual')
-    return SNR,rms
+        mask_image = maskname
 
+    if not os.path.exists(mask_image):
+        LOG.info('mask file %s does not exist', mask_image)
+        return np.float64(-99.0), np.float64(-99.0)
 
+    mad_to_rms = 1.4826
+    snr, rms = np.float64(-99.0), np.float64(-99.0)
 
-def estimate_near_field_SNR(imagename,las=None,maskname=None,verbose=True, mosaic_sub_field=False, save_near_field_mask=True):
-    if maskname is None:
-       maskImage=imagename.replace('image','mask').replace('.tt0','')
-    else:
-       maskImage=maskname
-    if not os.path.exists(maskImage):
-       print('Does not exist')
-       return np.float64(-99.0),np.float64(-99.0)
-    goodMask=checkmask(maskImage)
-    if not goodMask:
-       print('checkmask')
-       return np.float64(-99.0),np.float64(-99.0)
+    # Store tools to close at the end
+    tools_to_close = []
+    final_mask_name = imagename.replace('image', 'nearfield.mask').replace('.tt0', '')
 
-    MADtoRMS =  1.4826
-    headerlist = imhead(imagename, mode = 'list')
-    beammajor = headerlist['beammajor']['value']
-    beamminor = headerlist['beamminor']['value']
-    beampa = headerlist['beampa']['value']
+    try:
+        # Load Image Info
+        with casa_tools.ImageReader(imagename) as image:
+            bm = image.restoringbeam(polarization=0)
+            cs = image.coordsys()
+            incr = cs.increment()['numeric']
+            pixel_scale = np.abs(incr[0]) * 180 / np.pi * 3600.0
 
-    if mosaic_sub_field:
-        immath(imagename=[imagename, imagename.replace(".image",".pb"), imagename.replace(".image",".mospb")], outfile="temp.image", \
-                expr="IM0*IM1/IM2")
-        image_stats= imstat(imagename = "temp.image")
-        os.system("rm -rf temp.image")
-    else:
-        image_stats= imstat(imagename = imagename)
+            if mosaic_sub_field:
+                # Calculate corrected image stats in memory: image * pb / mospb
+                pb_path = imagename.replace('.image', '.pb')
+                mospb_path = imagename.replace('.image', '.mospb')
+                if not os.path.exists(pb_path) or not os.path.exists(mospb_path):
+                    raise FileNotFoundError(
+                        f'Required PB or MOSPB image not found for mosaic sub-field SNR calculation: {pb_path}, {mospb_path}'
+                    )
 
-    residualImage=imagename   # change to .image JT 04-15-2024 .replace('image','residual')
-    os.system('rm -rf temp.mask temp.residual temp.border.mask temp.smooth.ceiling.mask temp.smooth.mask temp.nearfield.mask temp.big.smooth.ceiling.mask temp.big.smooth.mask temp.nearfield.prepb.mask temp.beam.extent.image temp.delta temp.radius temp.image')
-    os.system('cp -r '+maskImage+ ' temp.mask')
-    os.system('cp -r '+residualImage+ ' temp.residual')   # keep as .residual to avoid clashing with another temp.image
-    residualImage='temp.residual'
-    maskStats=imstat(imagename='temp.mask')
-    imsmooth(imagename='temp.mask',kernel='gauss',major=str(beammajor*1.0)+'arcsec',minor=str(beammajor*1.0)+'arcsec', pa='0deg',outfile='temp.smooth.mask')
-    immath(imagename=['temp.smooth.mask'],expr='iif(IM0 > 0.1*max(IM0),1.0,0.0)',outfile='temp.smooth.ceiling.mask')
+                # LEL expression for mosaic correction
+                calc_expr = f"'{imagename}' * '{pb_path}' / '{mospb_path}'"
+                # Create a transient image for stats
+                ia_mospb_corr = image.imagecalc(outfile='', pixels=calc_expr)
+                tools_to_close.append(ia_mospb_corr)
+                image_stats = ia_mospb_corr.statistics(robust=False)
+            else:
+                image_stats = image.statistics(robust=False)
 
-    # Check the extent of the beam as well.
-    psfImage = maskImage.replace('mask','psf')+'.tt0'
+            peak_intensity = image_stats['max'][0]
 
-    immath(psfImage, mode="evalexpr", expr="iif(IM0==1,IM0,0)", outfile="temp.delta")
-    npix = imhead("temp.delta", mode="get", hdkey="shape")[0]
-    imsmooth("temp.delta", major=str(npix/2)+"pix", minor=str(npix/2)+"pix", pa="0deg", \
-            outfile="temp.radius", overwrite=True)
+        beammajor = bm['major']['value']
+        beamminor = bm['minor']['value']
+        beampa = bm['positionangle']['value']
 
-    bmin = imhead(imagename, mode="get", hdkey="BMIN")['value']
-    bmaj = imhead(imagename, mode="get", hdkey="BMAJ")['value']
-    bpa = imhead(imagename, mode="get", hdkey="BPA")['value']
+        good_mask = checkmask(mask_image)
+        if not good_mask:
+            LOG.info('The mask file %s is empty.', mask_image)
+            return np.float64(-99.0), np.float64(-99.0)
 
-    imhead(imagename="temp.radius", mode="put", hdkey="BMIN", hdvalue=str(bmin)+"arcsec")
-    imhead(imagename="temp.radius", mode="put", hdkey="BMAJ", hdvalue=str(bmaj)+"arcsec")
-    imhead(imagename="temp.radius", mode="put", hdkey="BPA", hdvalue=str(bpa)+"deg")
+        # 1. Smooth Mask (Small)
+        ia_mask = iatool()
+        ia_mask.open(mask_image)
+        tools_to_close.append(ia_mask)
 
-    immath(imagename=[psfImage,"temp.radius"], mode="evalexpr", expr="iif(IM0 > 0.1,1/IM1,0.0)", outfile="temp.beam.extent.image")
+        # outfile="" creates a transient image managed by the tool
+        ia_smooth = ia_mask.convolve2d(outfile='', major=f'{beammajor}arcsec', minor=f'{beammajor}arcsec', pa='0deg')
+        tools_to_close.append(ia_smooth)
 
-    centerpos = imhead(psfImage, mode="get", hdkey="maxpixpos")
-    maxpos = imhead("temp.beam.extent.image", mode="get", hdkey="maxpixpos")
-    center_coords = imval(psfImage, box=str(centerpos[0])+","+str(centerpos[1]))["coords"]
-    max_coords = imval(psfImage, box=str(maxpos[0])+","+str(maxpos[1]))["coords"]
+        smooth_stats = ia_smooth.statistics()
+        smooth_max = smooth_stats['max'][0]
 
-    beam_extent_size = ((center_coords - max_coords)**2)[0:2].sum()**0.5 * 360*60*60/(2*np.pi)
+        # Ceiling: iif(smooth > 0.1*max, 1.0, 0.0)
+        # We use the name() of the transient image in the LEL expression
+        ia_smooth.putchunk((ia_smooth.getchunk() > (0.1 * smooth_max)).astype(np.int8))
 
-    # use the maximum of the three possibilities as the outer extent of the mask.
-    print("beammajor*5 = ", beammajor*5, ", LAS = ", 5*las, ", beam_extent = ", beam_extent_size)
-    outer_major = max(beammajor*5, beam_extent_size, 5*las if las is not None else 0.)
+        # 2. Beam Extent from PSF (Calculated via transient images)
+        psf_image = mask_image.replace('mask', 'psf').replace('.tt0', '') + '.tt0'
+        if not os.path.exists(psf_image):
+            psf_image = mask_image.replace('mask', 'psf') + '.tt0'
 
-    imsmooth(imagename='temp.smooth.ceiling.mask',kernel='gauss',major=str(outer_major)+'arcsec',minor=str(outer_major)+'arcsec', pa='0deg',outfile='temp.big.smooth.mask')
+        beam_extent_size = 0.0
 
-    immath(imagename=['temp.big.smooth.mask'],expr='iif(IM0 > 0.01*max(IM0),1.0,0.0)',outfile='temp.big.smooth.ceiling.mask')
-    immath(imagename=['temp.big.smooth.ceiling.mask','temp.smooth.ceiling.mask'],expr='((IM0-IM1)-1.0)*-1.0',outfile='temp.nearfield.prepb.mask')
-    immath(imagename=[imagename,'temp.nearfield.prepb.mask'], expr='iif(MASK(IM0),IM1,1.0)',outfile='temp.nearfield.mask')
+        if os.path.exists(psf_image):
+            ia_psf = iatool()
+            ia_psf.open(psf_image)
+            tools_to_close.append(ia_psf)
 
-    maskImage='temp.nearfield.mask'
+            psf_stats = ia_psf.statistics()
+            # maxpos is [x, y, pol, chan] usually
+            max_pos = psf_stats['maxpos']
+            peak_x, peak_y = max_pos[0], max_pos[1]
 
-    mask_stats= imstat(maskImage)
-    if mask_stats['min'][0] == 1:
-       print('checkmask')
-       SNR, rms = np.float64(-99.0), np.float64(-99.0)
-    else:
-       ia.close()
-       ia.done()
-       ia.open(residualImage)
-       #ia.calcmask(maskImage+" <0.5"+"&& mask("+residualImage+")",name='madpbmask0')
-       ia.calcmask("'"+maskImage+"'"+" <0.5"+"&& mask("+residualImage+")",name='madpbmask0')
-       mask0Stats = ia.statistics(robust=True,axes=[0,1])
-       ia.maskhandler(op='set',name='madpbmask0')
-       rms = mask0Stats['medabsdevmed'][0] * MADtoRMS
-       residualMean = mask0Stats['median'][0]
-       peak_intensity = image_stats['max'][0]
-       SNR = peak_intensity/rms
-       if verbose:
-              print("#%s" % imagename)
-              print("#Beam %.3f arcsec x %.3f arcsec (%.2f deg)" % (beammajor, beamminor, beampa))
-              print("#Peak intensity of source: %.2f mJy/beam" % (peak_intensity*1000,))
-              print("#Near Field rms: %.2e mJy/beam" % (rms*1000,))
-              print("#Peak Near Field SNR: %.2f" % (SNR,))
-       ia.close()
-       ia.done()
+            # Calculate beam extent using numpy directly to avoid heavy convolution
+            # Find the max distance from the peak where PSF > 0.1
+            psf_data = ia_psf.getchunk()
 
-    if save_near_field_mask:
-        os.system('cp -r '+maskImage+' '+imagename.replace('image','nearfield.mask').replace('.tt0',''))
-    os.system('rm -rf temp.mask temp.residual temp.border.mask temp.smooth.ceiling.mask temp.smooth.mask temp.nearfield.mask temp.big.smooth.ceiling.mask temp.big.smooth.mask temp.nearfield.prepb.mask temp.beam.extent.image temp.delta temp.radius temp.image')
-    return SNR,rms
+            # Get spatial indices where data > 0.1
+            # psf_data is likely (nx, ny, npol, nchan)
+            indices = np.where(psf_data > 0.1)
+
+            if len(indices[0]) > 0:
+                # Calculate squared spatial distance from peak for all points > 0.1
+                # Use float64 to avoid overflow if image is huge
+                dx = indices[0].astype(np.float64) - peak_x
+                dy = indices[1].astype(np.float64) - peak_y
+                max_dist_sq = np.max(dx**2 + dy**2)
+                beam_extent_size = np.sqrt(max_dist_sq) * pixel_scale
+
+        LOG.info(
+            'beammajor*5 = %f, LAS = %f, beam_extent = %f',
+            beammajor * 5,
+            5 * las if las else 0.0,
+            beam_extent_size,
+        )
+        outer_major = max(beammajor * 5, beam_extent_size, 5 * las if las is not None else 0.0)
+
+        # 3. Big Smooth Mask (Outer Limit)
+        ia_big_smooth = ia_smooth.convolve2d(
+            outfile='',
+            major=f'{outer_major}arcsec',
+            minor=f'{outer_major}arcsec',
+            pa='0deg',
+        )
+        tools_to_close.append(ia_big_smooth)
+
+        big_stats = ia_big_smooth.statistics()
+        big_max = big_stats['max'][0]
+
+        # Label regions outside outer boundary as True
+        final_mask = ia_big_smooth.getchunk() < (0.01 * big_max)
+
+        # Label regions inside inner boundary as True
+        final_mask |= ia_smooth.getchunk() != 0  # in-place OR
+
+        # Label regions with bad pixels of the original image as True
+        # for casacore image built-in masks, True=Good, False=Bad
+        # note that for numpy.ma, True=Masked/Bad, False=Unmasked/Good
+        image = iatool()
+        image.open(imagename)
+        final_mask |= ~image.getchunk(getmask=True)
+        tools_to_close.append(image)
+
+        # Result: False in annulus (valid region), True elsewhere / masked
+        ia_big_smooth.putchunk(final_mask.astype(np.int8))
+        ia_annulus = ia_big_smooth.subimage(outfile=final_mask_name, overwrite=True, wantreturn=True)
+
+        tools_to_close.append(ia_annulus)
+
+        # 5. Calculate SNR & RMS in Annulus
+        annulus_stats = ia_annulus.statistics()
+        if annulus_stats['min'][0] >= 0.99:
+            LOG.info('Near field annulus is empty/fully masked.')
+        else:
+            with casa_tools.ImageReader(imagename) as ia_im:
+                # Use LEL mask expression: valid where annulus mask image value < 0.5
+                mask_expr = f"'{ia_annulus.name()}' < 0.5"
+                try:
+                    stats_final = ia_im.statistics(mask=mask_expr, robust=True)
+                    if len(stats_final['medabsdevmed']) > 0:
+                        rms = stats_final['medabsdevmed'][0] * mad_to_rms
+                        if rms > 0:
+                            snr = peak_intensity / rms
+                except Exception as e:
+                    LOG.warning('Error calculating stats: %s', e)
+
+            if verbose and rms > 0:
+                LOG.info('Image Name: %s', imagename)
+                LOG.info(
+                    'Beam: %.3f arcsec x %.3f arcsec (%.2f deg)',
+                    beammajor,
+                    beamminor,
+                    beampa,
+                )
+                LOG.info('Peak intensity of source: %.2f mJy/beam', peak_intensity * 1000)
+                LOG.info('Near Field rms: %.2e mJy/beam', rms * 1000)
+                LOG.info('Peak Near Field SNR: %.2f', snr)
+
+    except Exception:
+        LOG.error('Error in estimate_near_field_SNR: %s', traceback.format_exc())
+        return np.float64(-99.0), np.float64(-99.0)
+    finally:
+        # Cleanup transient tools
+        for tool in tools_to_close:
+            try:
+                tool.close()
+            except Exception:
+                pass
+
+    # 6. Clean up NF mask if saving final mask is not requested
+    if not save_near_field_mask:
+        if os.path.exists(final_mask_name):
+            shutil.rmtree(final_mask_name)
+
+    return snr, rms
 
 
 def get_intflux(imagename,rms,maskname=None,mosaic_sub_field=False):

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -2179,12 +2179,12 @@ def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library
        fov_y = fov+mosaic_size_y
        approx_npixels=np.max([fov_x/cell,fov_y/cell])
        buffer_pix=int(np.ceil(approx_npixels/10.0))
-       npixels_x = int(np.ceil(fov_x/cell / buffer_pix)) * buffer_pix
-       npixels_y = int(np.ceil(fov_y/cell / buffer_pix)) * buffer_pix
+       npixels_x = int(np.ceil(fov_x/cell / buffer_pix)) * buffer_pix + buffer_pix
+       npixels_y = int(np.ceil(fov_y/cell / buffer_pix)) * buffer_pix + buffer_pix
        npixels=[npixels_x,npixels_y]
    else:
        buffer_pix=int(np.ceil(fov/cell/10.0))
-       pixels=int(np.ceil(fov/cell / buffer_pix)) * buffer_pix
+       pixels=int(np.ceil(fov/cell / buffer_pix)) * buffer_pix + buffer_pix
        npixels=[pixels,pixels]
    if np.max(npixels) > 16384:
       if mosaic:

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -1214,11 +1214,11 @@ def checkmask(imagename):
       return True
 
 def estimate_SNR(
-    imagename: str,
-    maskname: str | None = None,
-    verbose: bool = True,
-    mosaic_sub_field: bool = False,
-) -> tuple[float, float]:
+    imagename,
+    maskname=None,
+    verbose=True,
+    mosaic_sub_field=False,
+):
     """Estimate the Signal-to-Noise Ratio (SNR) of an image.
 
     This function calculates the SNR by determining the peak intensity (considering
@@ -1333,13 +1333,13 @@ def estimate_SNR(
 
 
 def estimate_near_field_SNR(
-    imagename: str,
-    las: float | None = None,
-    maskname: str | None = None,
-    verbose: bool = True,
-    mosaic_sub_field: bool = False,
-    save_near_field_mask: bool = True,
-) -> tuple[float, float]:
+    imagename,
+    las=None,
+    maskname=None,
+    verbose=True,
+    mosaic_sub_field=False,
+    save_near_field_mask=True,
+):
     """Estimate the near-field SNR using in-memory CASA tool operations.
 
     This function avoids writing temporary images to disk and minimizes large numpy array

--- a/auto_selfcal/selfcal_helpers.py
+++ b/auto_selfcal/selfcal_helpers.py
@@ -2149,32 +2149,15 @@ def get_image_parameters(vislist,telescope,target,field_ids,band,selfcal_library
    fov=fov*scale_fov
 
    if mosaic:
-       max_fields=0
-       index_max_fields=0
-       for v,vis in enumerate(vislist):
-          n_fields_vis=len(selfcal_library[target][band]['sub-fields-fid_map'][vislist[v]].keys())
-          if n_fields_vis > max_fields:
-              max_fields=n_fields_vis+0
-              index_max_fields=v+0
-
-       msmd.open(vislist[index_max_fields])
-       #get field IDs for VLA and and ALMA differently
-       #if telescope == 'ALMA' or telescope == 'ACA':
-       #   fieldid=msmd.fieldsforname(target)
-       #elif 'VLA' in telescope:
-       fieldid=np.array([],dtype=int)
-       for fid in selfcal_library[target][band]['sub-fields']:
-         if fid in selfcal_library[target][band]['sub-fields-fid_map'][vislist[index_max_fields]].keys():
-            field_id=selfcal_library[target][band]['sub-fields-fid_map'][vislist[index_max_fields]][fid]
-            fieldid=np.append(fieldid,np.array([field_id]))
+       fieldid=selfcal_library[target][band]['sub-fields-phasecenters'].keys()
 
        ra_phasecenter_arr=np.zeros(len(fieldid))
        dec_phasecenter_arr=np.zeros(len(fieldid))
-       for i in range(len(fieldid)):
-          phasecenter=msmd.phasecenter(fieldid[i])
-          ra_phasecenter_arr[i]=phasecenter['m0']['value']
-          dec_phasecenter_arr[i]=phasecenter['m1']['value']
-       msmd.done()
+
+       for k, key in enumerate(fieldid):
+          ra_phasecenter_arr[i]=selfcal_library[target][band]['sub-fields-phasecenters'][key][0]
+          dec_phasecenter_arr[i]=selfcal_library[target][band]['sub-fields-phasecenters'][key][1]
+
        median_dec=np.median(dec_phasecenter_arr)
        mosaic_size_x=(ra_phasecenter_arr.max() - ra_phasecenter_arr.min()) * 180./np.pi * 3600. *np.cos(median_dec)
        mosaic_size_y=(dec_phasecenter_arr.max() - dec_phasecenter_arr.min()) * 180./np.pi * 3600.
@@ -3091,21 +3074,15 @@ def check_mosaic(vislist,target):
    return mosaic
 
 def get_phasecenter(vis,selfcal_library,field,telescope):
-   msmd.open(vis)
-   fieldid=np.array([],dtype=int)
-   for fid in selfcal_library['sub-fields']:
-      if fid in selfcal_library['sub-fields-fid_map'][vis].keys():
-         field_id=selfcal_library['sub-fields-fid_map'][vis][fid]
-         fieldid=np.append(fieldid,np.array([field_id]))
+   fieldid=selfcal_library[target][band]['sub-fields-phasecenters'].keys()
 
    ra_phasecenter_arr=np.zeros(len(fieldid))
    dec_phasecenter_arr=np.zeros(len(fieldid))
-   for i in range(len(fieldid)):
-      phasecenter=msmd.phasecenter(fieldid[i])
-      ra_phasecenter_arr[i]=phasecenter['m0']['value']
-      dec_phasecenter_arr[i]=phasecenter['m1']['value']
 
-   msmd.done()
+   for k, key in enumerate(fieldid):
+      ra_phasecenter_arr[i]=selfcal_library[target][band]['sub-fields-phasecenters'][key][0]
+      dec_phasecenter_arr[i]=selfcal_library[target][band]['sub-fields-phasecenters'][key][1]
+
    #RA center = Min + delta ra
    ra_phasecenter=np.min(ra_phasecenter_arr)+(np.max(ra_phasecenter_arr)-np.min(ra_phasecenter_arr))/2.0
    dphi_dec=np.abs((np.max(dec_phasecenter_arr)-np.min(dec_phasecenter_arr))/2.0)

--- a/auto_selfcal/tests/test_auto_selfcal.py
+++ b/auto_selfcal/tests/test_auto_selfcal.py
@@ -72,10 +72,10 @@ def test_benchmark(tmp_path, dataset):
 @pytest.mark.parametrize(
     "zip_file,link",
     [
-        pytest.param("2018.1.01284.S_HOPS-384.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/Ea8NGWjlNptNnyqg_62xxmcB0lk64IpB7Dd7AgfltnNkXQ?e=pATHrR&download=1', id="2018.1.01284.S_HOPS-384"),
-        pytest.param("Band8-7m-2.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/EScVSXH9JHRIt2P-9fwxVRYBsy70G94cKxv00HTv44Pdug?e=W1zfyP&download=1', id="Band8-7m-2"),
-        pytest.param("M82-C-conf-C-band_small.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/EZP4KRsBbthPksh6_kKsNI4Bm3m4L-1QhF4zCUDXhO73Lg?e=tmcIMv&download=1', id="M82-C-conf-C-band_small"),
-        pytest.param("K-band-mini-mosaic.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQBCQc-REEGYQrBwBu2F9uUTAfpCRQq1gYAPO18e-CL_IUk?e=Tc2ywo&download=1', id='K-band-mini-mosaic')
+        pytest.param("2018.1.01284.S_HOPS-384.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQCvDRlo5TabTZ8qoP-tscZnAdJZOuCKQew3ewIH5bZzZF0?e=oiYqaJ&download=1', id="2018.1.01284.S_HOPS-384"),
+        pytest.param("Band8-7m-2.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQAnFUlx_SR0SLdj_vX8MVUWAbMu9BveHCsb9NB07-OD3bo?e=GX3RXd&download=1', id="Band8-7m-2"),
+        pytest.param("M82-C-conf-C-band_small.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQCT-CkbAW7YT5LIev5CrDSOAZt5uC_tUIReMwlA14Tu9y4?e=veTEno&download=1', id="M82-C-conf-C-band_small"),
+        pytest.param("K-band-mini-mosaic.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQBCQc-REEGYQrBwBu2F9uUTAfpCRQq1gYAPO18e-CL_IUk?e=ldigb1&download=1', id='K-band-mini-mosaic')
     ]
 )
 def test_on_github(tmp_path, request, zip_file, link):

--- a/auto_selfcal/tests/test_auto_selfcal.py
+++ b/auto_selfcal/tests/test_auto_selfcal.py
@@ -68,14 +68,16 @@ def test_benchmark(tmp_path, dataset):
 
     assert difference_count == 0
 
+# Note for future reference: to create the tar file properly, update the files in the folder on OneDrive, and then run:
+# tar czf Band8-7m-2.tar.gz -c Band8-7m-2 .
 @pytest.mark.ghtest
 @pytest.mark.parametrize(
     "zip_file,link",
     [
-        pytest.param("2018.1.01284.S_HOPS-384.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQCvDRlo5TabTZ8qoP-tscZnAdJZOuCKQew3ewIH5bZzZF0?e=oiYqaJ&download=1', id="2018.1.01284.S_HOPS-384"),
-        pytest.param("Band8-7m-2.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQAnFUlx_SR0SLdj_vX8MVUWAbMu9BveHCsb9NB07-OD3bo?e=GX3RXd&download=1', id="Band8-7m-2"),
-        pytest.param("M82-C-conf-C-band_small.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQCT-CkbAW7YT5LIev5CrDSOAZt5uC_tUIReMwlA14Tu9y4?e=veTEno&download=1', id="M82-C-conf-C-band_small"),
-        pytest.param("K-band-mini-mosaic.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQBCQc-REEGYQrBwBu2F9uUTAfpCRQq1gYAPO18e-CL_IUk?e=ldigb1&download=1', id='K-band-mini-mosaic')
+        pytest.param("2018.1.01284.S_HOPS-384.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQCvDRlo5TabTZ8qoP-tscZnAdJZOuCKQew3ewIH5bZzZF0?e=XWOGxH&download=1', id="2018.1.01284.S_HOPS-384"),
+        pytest.param("Band8-7m-2.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQAnFUlx_SR0SLdj_vX8MVUWAbMu9BveHCsb9NB07-OD3bo?e=zMGxOJ&download=1', id="Band8-7m-2"),
+        pytest.param("M82-C-conf-C-band_small.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQCT-CkbAW7YT5LIev5CrDSOAZt5uC_tUIReMwlA14Tu9y4?e=2zF126&download=1', id="M82-C-conf-C-band_small"),
+        pytest.param("K-band-mini-mosaic.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQBCQc-REEGYQrBwBu2F9uUTAfpCRQq1gYAPO18e-CL_IUk?e=7adSCD&download=1', id='K-band-mini-mosaic')
     ]
 )
 def test_on_github(tmp_path, request, zip_file, link):


### PR DESCRIPTION
Following along with PIPE-2937/PIPE-2983, use @r-xue's updates for PL selfcal that replace the temporary files created by the estimate_SNR and estimate_near_field_SNR with CASA in-memory operations.

Per that ticket, those functions have the "... potential to write out as many as 13 temp image during NF SNR calculaton: if the temp images are large, and we have multiple concurent selfcal workder running, there is a chance the process might "trash" node pagecache and even trigger swap due to the our node setup tendency to cache lustre I/O ("just in case they get used again"), this behavior can cause a persist memory pressure even when the function has completed."