### PR TITLE
Delete MS files after benchmark runs are done to save space

### DIFF
--- a/auto_selfcal/tests/test_auto_selfcal.py
+++ b/auto_selfcal/tests/test_auto_selfcal.py
@@ -69,6 +69,9 @@ def test_benchmark(tmp_path, dataset):
          'am_dogrowprune','am_growiterations','am_lownoisethreshold','am_minbeamfrac',\
          'am_noisethreshold','am_sidelobethreshold','am_smoothfactor'])
 
+    for msfile in starting_MS_files:
+        print(f"rm -rf {os.path.basename(msfile)}")
+
     assert difference_count == 0
 
 # Note for future reference: to create the tar file properly, update the files in the folder on OneDrive, and then run:


### PR DESCRIPTION
Small change to the the benchmark tests we run locally to clean up the MS files after they are run to save space. This is minor and only affects local tests, so I think it should be safe to merge.