### PR TITLE
Add a test that includes a usermask and usermodel.

### DIFF
--- a/auto_selfcal/tests/test_auto_selfcal.py
+++ b/auto_selfcal/tests/test_auto_selfcal.py
@@ -84,7 +84,7 @@ def test_benchmark(tmp_path, dataset):
         pytest.param("Band8-7m-2.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQAnFUlx_SR0SLdj_vX8MVUWAbMu9BveHCsb9NB07-OD3bo?e=zMGxOJ&download=1', id="Band8-7m-2"),
         pytest.param("M82-C-conf-C-band_small.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQCT-CkbAW7YT5LIev5CrDSOAZt5uC_tUIReMwlA14Tu9y4?e=2zF126&download=1', id="M82-C-conf-C-band_small"),
         pytest.param("K-band-mini-mosaic.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQBCQc-REEGYQrBwBu2F9uUTAfpCRQq1gYAPO18e-CL_IUk?e=7adSCD&download=1', id='K-band-mini-mosaic'),
-        pytest.param("2019.1.00691.S_SB.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQAoeNLrwb1aSrWCfo8ekE6NAXVJ4Qlpps0gdAeY1U9Axn0?e=xyU2MO&download=1', id='2019.1.00691.S_SB')
+        pytest.param("2019.1.00691.S_SB.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQAoeNLrwb1aSrWCfo8ekE6NAXVJ4Qlpps0gdAeY1U9Axn0?e=MMXCaT&download=1', id='2019.1.00691.S_SB')
     ]
 )
 def test_on_github(tmp_path, request, zip_file, link):

--- a/auto_selfcal/tests/test_auto_selfcal.py
+++ b/auto_selfcal/tests/test_auto_selfcal.py
@@ -83,7 +83,8 @@ def test_benchmark(tmp_path, dataset):
         pytest.param("2018.1.01284.S_HOPS-384.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQCvDRlo5TabTZ8qoP-tscZnAdJZOuCKQew3ewIH5bZzZF0?e=XWOGxH&download=1', id="2018.1.01284.S_HOPS-384"),
         pytest.param("Band8-7m-2.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQAnFUlx_SR0SLdj_vX8MVUWAbMu9BveHCsb9NB07-OD3bo?e=zMGxOJ&download=1', id="Band8-7m-2"),
         pytest.param("M82-C-conf-C-band_small.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQCT-CkbAW7YT5LIev5CrDSOAZt5uC_tUIReMwlA14Tu9y4?e=2zF126&download=1', id="M82-C-conf-C-band_small"),
-        pytest.param("K-band-mini-mosaic.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQBCQc-REEGYQrBwBu2F9uUTAfpCRQq1gYAPO18e-CL_IUk?e=7adSCD&download=1', id='K-band-mini-mosaic')
+        pytest.param("K-band-mini-mosaic.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQBCQc-REEGYQrBwBu2F9uUTAfpCRQq1gYAPO18e-CL_IUk?e=7adSCD&download=1', id='K-band-mini-mosaic'),
+        pytest.param("2019.1.00691.S_SB.tar.gz", 'https://nrao-my.sharepoint.com/:u:/g/personal/psheehan_nrao_edu/IQAoeNLrwb1aSrWCfo8ekE6NAXVJ4Qlpps0gdAeY1U9Axn0?e=xyU2MO&download=1', id='2019.1.00691.S_SB')
     ]
 )
 def test_on_github(tmp_path, request, zip_file, link):
@@ -96,7 +97,17 @@ def test_on_github(tmp_path, request, zip_file, link):
     os.system(f'tar xf {zip_file}')
     os.system(f'rm -rf {zip_file}')
 
-    auto_selfcal(sort_targets_and_EBs=True, weblog=True)
+    if len(glob.glob("usermask.mask")) > 0:
+        usermask = {"HOPS_358": {"Band_7": "usermask.mask"}}
+    else:
+        usermask = {}
+
+    if len(glob.glob("usermodel.*")) > 0:
+        usermodel = {"HOPS_358": {"Band_7": ["usermodel.model.tt0", "usermodel.model.tt1"]}}
+    else:
+        usermodel = {}
+
+    auto_selfcal(sort_targets_and_EBs=True, weblog=True, usermask=usermask, usermodel=usermodel)
 
     os.system('rm -rf *.ms*') # Delete MS files as space is limited on GitHub.
 


### PR DESCRIPTION
This PR adds a test that uses a usermask and a usermodel to make sure those parts of the code are exercised. Since it is an ALMA dataset (not ACA like other current tests) and goes all the way to amplitude calibration, it will also add some additional coverage. It doesn't run super quickly, but hopefully it doesn't add too much time.

At the moment I expect the new test to fail as there are no reference values yet. After the action is run, I can upload the reference values and update the test tarball.