### PR TITLE
Force reinstall pytest during installation into monolithic CASA in case the pytest delivered is already up-to-date

### DIFF
--- a/auto_selfcal/__init__.py
+++ b/auto_selfcal/__init__.py
@@ -11,7 +11,7 @@ try:
             try:
                 import pytest
                 os.system(f'cd {casa_path}/bin; ln -s casa pytest')
-                os.system(f'{casa_path}/bin/pip3 install --upgrade pytest')
+                os.system(f'{casa_path}/bin/pip3 install --upgrade --force-reinstall pytest')
             except:
                 pass
 except:


### PR DESCRIPTION
Using pytest within monolithic CASA requires replacing the version delivered with monolithic CASA. This is handled under-the-hood in the `auto_selfcal.setup_monolithic_CASA` function, but right now uses only `--upgrade`, assuming that the pytest version is out of date. If the pytest delivered with monolithic CASA is up-to-date, this will do nothing, and pytest remains broken. To remedy this, this PR adds the `--force-reinstall` flag to force pytest to be reinstalled, even if it is up-to-date already.